### PR TITLE
Solves issue "#1 Add initial project scaffolding and documentation"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,117 @@
+# Bash-centric pre-commit configuration for claude-session.
+#
+# Tailored from the dotfiles bash template. Re-add the bats-tests hook
+# (commented at the bottom) once `test/` is scaffolded with bats tests.
+
+default_install_hook_types: [pre-commit, commit-msg, pre-push]
+
+repos:
+  # Generic housekeeping hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: trailing-whitespace
+        args: [--markdown-linebreak-ext=md]
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-toml
+      - id: pretty-format-json
+        args: ["--autofix", "--no-ensure-ascii", "--no-sort-keys", "--indent=2"]
+        exclude: >-
+          (?x)((^|/)devcontainer\.json$|[-.]lock\.json$)
+      - id: check-added-large-files
+        args: ["--maxkb=2048"]
+      - id: detect-private-key
+      - id: check-executables-have-shebangs
+      - id: check-merge-conflict
+      - id: check-case-conflict
+      - id: check-shebang-scripts-are-executable
+      - id: no-commit-to-branch
+        args: [--branch, develop, --branch, main, --branch, master]
+
+  - repo: https://github.com/maresb/check-json5
+    rev: v1.0.1
+    hooks:
+      - id: check-json5
+        exclude: '[-.]lock\.json$'
+
+  # ShellCheck – static analysis
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+
+  # shfmt – code formatter
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      - id: shfmt
+        args: ["-i", "2", "-ci"]   # 2-space indent, keep control-indented
+
+  # bashate – style checker
+  - repo: https://github.com/openstack/bashate
+    rev: 2.1.1
+    hooks:
+      - id: bashate
+        args: ["-i", "E003,E006", "-e", "E005"]  # allow 2-space indent; error on tabs
+        exclude: ^test/(.*\.bats|test_helper(/.*|\.bash))$
+
+  # Pre-commit hook to check for spelling mistakes
+  - repo: https://github.com/crate-ci/typos
+    rev: v1.45.1
+    hooks:
+      - id: typos
+        args: ["--write-changes"]
+
+  # gitleaks – secret scanner (critical: this is a public repo)
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.1
+    hooks:
+      - id: gitleaks
+        pass_filenames: false      # let gitleaks handle its own scanning scope
+        stages: [pre-commit]
+
+  # shellharden – auto-quote variables and command substitutions
+  # Requires `shellharden` on PATH (cargo install shellharden).
+  - repo: local
+    hooks:
+      - id: shellharden
+        name: shellharden
+        language: system
+        entry: shellharden --replace
+        types: [shell]
+
+  # gitlint – commit-message linter
+  - repo: https://github.com/jorisroovers/gitlint
+    rev: v0.19.1
+    hooks:
+      - id: gitlint
+        stages: [commit-msg]       # only run on commit-message hook
+        types_or: [text]
+
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v4.13.9
+    hooks:
+      - id: commitizen
+      - id: commitizen-branch
+        stages: [pre-push]
+
+  # Meta hooks that audit this config against the repo's tracked files.
+  # Deferred until shell sources land — until then they flag the
+  # bash-centric hooks (shellcheck, shfmt, bashate, shellharden) and
+  # their excludes as "not applying", which is expected during scaffolding.
+  # - repo: meta
+  #   hooks:
+  #     - id: check-hooks-apply
+  #     - id: check-useless-excludes
+
+  # bats – Bash Automated Testing System.
+  # Re-enable once `test/` exists with bats tests:
+  # - repo: local
+  #   hooks:
+  #     - id: bats-tests
+  #       name: bats tests
+  #       language: system
+  #       entry: bats test
+  #       pass_filenames: false
+  #       always_run: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,99 @@
+# AGENTS.md
+
+Cross-agent context for AI coding agents (Codex CLI, Claude Code, Cursor,
+Gemini CLI, and any tool that reads `AGENTS.md`).
+
+## What this project is
+
+`claude-session` is a bash CLI that wraps the `claude` binary to give each
+terminal its own isolated `CLAUDE_CONFIG_DIR`, while transparently sharing
+portable config (auth, settings, skills, agents, rules, commands, hooks)
+back to `~/.claude/`. It prevents cross-terminal state bleed in Claude Code.
+
+It is a **public repository**. No organization identifiers, personal project
+IDs, OAuth tokens, secret-store paths, or profile names tied to an employer
+or individual may be committed. When in doubt, generalize into a config
+variable.
+
+## Tech stack
+
+- **Language**: bash 4.4+ (`set -euo pipefail`, `shopt -s inherit_errexit`).
+- **Build / task runner**: [`just`](https://just.systems/) (see `justfile`).
+- **Tests**: [`bats-core`](https://bats-core.readthedocs.io/) with
+  `bats-support` / `bats-assert` / `bats-file` as git submodules under
+  `test/test_helper/`.
+- **Linting**: [`shellcheck`](https://www.shellcheck.net/) and
+  [`shfmt`](https://github.com/mvdan/sh), orchestrated through
+  [`pre-commit`](https://pre-commit.com/). **Never invoke linters directly;
+  always run them through pre-commit.**
+- **Man page**: [`scdoc`](https://git.sr.ht/~sircmpwn/scdoc) source in
+  `man/*.scd`, compiled to `.1` by `just man`.
+- **Runtime dependencies**: `jq` (settings overlay merge), `flock`
+  (exit-time sync under lock).
+
+## Build, test, lint
+
+Before any PR:
+
+```sh
+just check        # runs lint + test (unit + integration)
+```
+
+Subsets:
+
+```sh
+just test-unit         # fast bats unit tests
+just test-integration  # bats integration tests (touch filesystem)
+just lint              # pre-commit run --all-files
+just man               # build man page
+```
+
+## Where things live
+
+- Source: `bin/claude-session` (entry shim) + `lib/` (loader, core,
+  helpers, `commands/`, `functions/`).
+- Specs (source of truth for design intent): `docs/`.
+- Start with `docs/architecture.md` for the module layout and startup
+  flow, then `docs/commands.md` for the user-facing surface.
+- Full per-subcommand reference: `docs/commands.md`.
+- Config file format and env vars: `docs/config.md`.
+- Contributor / dev workflow: `docs/development.md`.
+
+## Conventions
+
+- **Commit style**: [Conventional Commits](https://www.conventionalcommits.org/).
+- **Namespace**: public functions are `cs::cmd::<n>`, `cs::fn::<n>`,
+  `cs::helpers::<n>`. Private helpers (same-file only) are `__<n>`.
+- **One public function per file** under `lib/commands/` and
+  `lib/functions/`; filename mirrors the function name.
+- **Every `.sh` under `lib/`** starts with `# shellcheck shell=bash`
+  followed by `: 'desc: <one-line description>'` (harvested by help/man
+  generators — see `docs/development.md`).
+- **stdout vs stderr**: data → stdout, progress/warnings/errors → stderr.
+  `printf` over `echo`. No ANSI escape codes unless `[[ -t 1 ]]`.
+- **Error shape**: three-part (`What went wrong:` / `How to fix:` /
+  `Next:`) on stderr; non-zero exit code. Template in
+  `docs/architecture.md`.
+- **Exit codes**: documented in `docs/commands.md`; agents may rely on
+  them as a stable contract.
+
+## Negative scope
+
+- Do **not** commit configuration containing organization identifiers
+  (cloud project IDs, internal hostnames, secret-store paths), OAuth
+  tokens, or profile names that identify individuals / employers.
+- Do **not** add an MCP shim, a SKILL.md, or a cross-agent skill package
+  in this repo — those are planned as separate downstream repos.
+- Do **not** add `--json` output, `schema <type>`, or verify/validate
+  subcommands in v1. They are deferred to v1.1+ (see
+  `docs/features.md` → "Deferred").
+
+## References
+
+The design draws on two internal references:
+
+- Bash CLI project layout, strict mode, XDG install, testing — see
+  `docs/architecture.md` and `docs/development.md`.
+- Agent-facing CLI surface (`--help`, `usage`, `doctor`, error shape,
+  exit codes, config precedence) — see `docs/commands.md` §"Per-subcommand
+  reference".

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# CLAUDE.md
+
+Claude Code specific guardrails for this repository. For broader
+cross-agent context (tech stack, build commands, negative scope), see
+[AGENTS.md](AGENTS.md).
+
+## About this repo
+
+`claude-session` is a **public** bash CLI that isolates `CLAUDE_CONFIG_DIR`
+per terminal. It is a generalized port of a personal wrapper script — all
+organization-specific values must be user-configurable, never hard-coded.
+
+## Canonical specs
+
+Design intent lives in [`docs/`](docs/). Before changing behavior,
+read the relevant spec file:
+
+- `docs/architecture.md` — module layout, startup flow, session-dir lifecycle.
+- `docs/commands.md` — user-facing surface (every subcommand, flag, exit code).
+- `docs/config.md` — config file format, env var reference.
+- `docs/features.md` — scope of v1 and what's deferred.
+
+## Before committing
+
+Run:
+
+```sh
+just check
+```
+
+This runs the full lint + test matrix. **Linting always goes through
+`pre-commit`** — never invoke `shellcheck`, `shfmt`, or other linters
+directly. If `pre-commit run --all-files` is clean, linting is clean.
+
+## Public-repo hygiene (hard rules)
+
+- Never commit organization-specific cloud project IDs (e.g. any
+  `vertex-ai-*`, internal GCP/AWS project slugs).
+- Never commit OAuth tokens, API keys, or secrets of any kind.
+- Never commit paths to personal secret stores (e.g. `gopass show …`).
+- Never commit profile names that identify individuals or employers.
+  Example names must be generic: `default`, `work`, `experiment`, `vertex`.
+- If a command, flag, or env var would need personal data to work,
+  that personal data belongs in the user's
+  `~/.config/claude-session/config.env` — not in the repo.
+
+Any value that could be sensitive should be introduced as a generic env
+var documented in `docs/config.md`, with a placeholder in examples
+(e.g. `<your-gcp-project-id>`).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,122 @@
 # claude-session
+
+> Per-terminal session isolation for Claude Code, as a proper agent-friendly bash CLI.
+
+`claude-session` is a thin wrapper around the `claude` binary that gives each
+terminal its own `CLAUDE_CONFIG_DIR`, with shared portable config (auth,
+settings, skills) transparently linked back to `~/.claude/`. Session-specific
+state (history, projects, todos, plans) stays isolated per terminal.
+
+## What it does
+
+- **Per-terminal isolation**: each `tty` (e.g. `pts/0`, `pts/1`) gets its own
+  session directory under `$XDG_RUNTIME_DIR/claude-session/sessions/`
+  (or the XDG-spec `${XDG_STATE_HOME:-$HOME/.local/state}/claude-session/sessions/`
+  fallback when no runtime dir is available); no cross-bleed
+  of prompts, todos, or project metadata between terminals.
+- **Profile-based settings overlays**: layer a user-named profile's
+  `settings.<profile>.json` atop `settings.base.json` at startup via `jq`.
+- **Configurable OAuth and post-exit hooks**: run any command to supply an
+  OAuth token at startup, run any command after `claude` exits (cost sync,
+  analytics, cleanup). Both optional; nothing personal ships in the repo.
+- **XDG-aware install**: user install under `~/.local/`, system install under
+  `$PREFIX/`, all paths follow the XDG Base Directory spec.
+- **Scriptable / agent-friendly**: per-subcommand `--help`, three-part error
+  shape, `doctor` subcommand for structured health checks, `usage` for full
+  command-tree introspection, stable exit codes, no ANSI on non-tty output.
+
+## Why it exists
+
+When several terminals attach to the same machine (or devcontainer) and all
+run Claude Code, they share `~/.claude/` — and with it, in-flight prompts,
+session history, todo lists, and project metadata. State from one terminal
+leaks into another, prompts reappear out of context, and todos become chaotic.
+
+`claude-session` fixes this by giving each terminal a dedicated
+`CLAUDE_CONFIG_DIR`, with symlinks back to the portable bits (auth tokens,
+global settings, skills, agents, rules, commands, hooks) and atomic copy-sync
+for files Claude Code rewrites (like `.credentials.json`). The deeper design
+lives in [docs/architecture.md](docs/architecture.md).
+
+## Quick start
+
+Install (user scope):
+
+```sh
+git clone <this-repo> claude-session
+cd claude-session
+just install
+```
+
+Create a minimal config:
+
+```sh
+mkdir -p ~/.config/claude-session
+cat > ~/.config/claude-session/config.env <<'EOF'
+CLAUDE_SESSION_PROFILE=default
+EOF
+```
+
+Wrap your shell's `claude` invocation:
+
+```sh
+# ~/.bashrc or equivalent
+alias claude='claude-session run'
+```
+
+Verify:
+
+```sh
+claude-session doctor
+```
+
+Now each new terminal gets its own session directory the first time you run
+`claude`.
+
+## Command tree
+
+```
+claude-session
+├── run [--profile <n>] [-- <claude_args>...]
+├── doctor [--verbose]
+├── usage
+├── config   (show | path | edit)
+├── profile  (list | show <name>)
+└── session  (list | clean [--older-than <dur>] [--dry-run] [--yes])
+```
+
+Full reference: [docs/commands.md](docs/commands.md).
+
+## Configuration
+
+Config precedence is **CLI flags > environment variables > config file**.
+The main config file is a dotenv-style `~/.config/claude-session/config.env`;
+per-profile overrides live under `~/.config/claude-session/profiles/<name>.env`.
+Full reference and env-var table: [docs/config.md](docs/config.md).
+
+## Requirements
+
+- bash 4.4+
+- `jq` (for settings overlay merge)
+- `just` (optional; `install.sh` works standalone if you'd rather skip it)
+
+## Documentation
+
+- [docs/architecture.md](docs/architecture.md) — module layout, startup flow, session-dir lifecycle.
+- [docs/features.md](docs/features.md) — feature inventory (ported / generalized / new).
+- [docs/config.md](docs/config.md) — config file format, env vars, profile system.
+- [docs/commands.md](docs/commands.md) — every subcommand, flag, exit code, and example.
+- [docs/install.md](docs/install.md) — install matrix, `just` recipes, uninstall.
+- [docs/development.md](docs/development.md) — dev setup, tests, linting, CI.
+- [AGENTS.md](AGENTS.md) — cross-agent (Codex / Claude Code / Cursor / Gemini) context.
+- [CLAUDE.md](CLAUDE.md) — Claude Code guardrails for this repo.
+
+## Contributing
+
+See [docs/development.md](docs/development.md) for environment setup,
+strict-mode policy, test layout, and the pre-commit linting workflow.
+Run `just check` before opening a pull request.
+
+## License
+
+MIT. See `LICENSE`.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,372 @@
+# Architecture
+
+This document describes the internal design of `claude-session`: directory
+layout, function-namespacing convention, startup flow, and the session-dir
+lifecycle. It is the spec that `lib/` source code must conform to.
+
+## Directory layout
+
+```
+claude-session/
+├── bin/
+│   └── claude-session               # thin entry shim: loader → cs::main
+├── lib/
+│   ├── loader.sh                    # source-on-dispatch
+│   ├── core.sh                      # cs::main, global flags, dispatch
+│   ├── helpers.sh                   # cs::helpers::* (error shape, log, die, require)
+│   ├── commands/                    # one public cs::cmd::<n> per file
+│   │   ├── cmd_run.sh               # default: wrap the real claude binary
+│   │   ├── cmd_doctor.sh
+│   │   ├── cmd_usage.sh
+│   │   ├── cmd_config.sh            # show | path | edit
+│   │   ├── cmd_profile.sh           # list | show
+│   │   └── cmd_session.sh           # list | clean
+│   └── functions/                   # one public cs::fn::<n> per file
+│       ├── fn_load_config.sh
+│       ├── fn_resolve_profile.sh
+│       ├── fn_real_claude.sh        # discover the real claude binary
+│       ├── fn_session_dir.sh        # secure session-dir selection
+│       ├── fn_terminal_id.sh        # tty-based id with PID fallback
+│       ├── fn_merge_settings.sh     # jq -s '.[0] * .[1]' overlay
+│       ├── fn_sync_files.sh         # copy-based sync (atomic temp+rename)
+│       ├── fn_link_files.sh         # symlink files / dirs
+│       ├── fn_run_hook.sh           # run user-supplied hook command
+│       ├── fn_session_inventory.sh  # walk sessions/, classify active/stale, render table
+│       └── fn_error.sh              # three-part error emitter
+├── completions/
+│   └── claude-session.bash
+├── man/
+│   └── claude-session.1.scd         # scdoc source → claude-session.1
+├── test/
+│   ├── test_helper.bash             # common setup; loads bats-* submodules
+│   ├── test_helper/
+│   │   ├── bats-support/            # submodule
+│   │   ├── bats-assert/             # submodule
+│   │   └── bats-file/               # submodule
+│   ├── cmd_<name>_test.bats         # per-command tests
+│   └── fn_<name>_test.bats          # per-function tests
+├── .shellcheckrc
+├── .pre-commit-config.yaml
+├── .editorconfig
+├── justfile
+├── install.sh                       # invoked by `just install`
+└── uninstall.sh                     # invoked by `just uninstall`
+```
+
+Test filename convention is `<module>_test.bats` (suffix, not prefix) to
+match the convention used across the repository owner's other bash CLIs.
+
+## Namespace convention
+
+| Prefix                | Role                                               |
+|-----------------------|----------------------------------------------------|
+| `cs::cmd::<n>`        | Subcommand entry point. One per `lib/commands/cmd_<n>.sh`. |
+| `cs::fn::<n>`         | Reusable public helper. One per `lib/functions/fn_<n>.sh`. |
+| `cs::helpers::<n>`    | Shared low-level utilities defined in `lib/helpers.sh`.    |
+| `__<n>`               | Private helper, scoped to the file that defines it. Never called cross-file. |
+
+Every `.sh` file under `lib/` starts with:
+
+```bash
+# shellcheck shell=bash
+: 'desc: <one-line description of what this file defines>'
+```
+
+- No shebang under `lib/` — these files are sourced, never executed.
+- The `desc:` sentinel is harvested by help/man generators.
+
+## Entry flow
+
+1. `bin/claude-session` is the only shebanged file. It:
+   - sets strict mode (`set -euo pipefail; shopt -s inherit_errexit`),
+   - resolves its own path through symlinks (so `stow` / `ln -s` in
+     `~/.local/bin` work),
+   - computes `SCRIPT_DIR` and `LIB_DIR`,
+   - sources `lib/helpers.sh`, `lib/loader.sh`, `lib/core.sh` (in that
+     order),
+   - calls `cs::main "$@"`.
+2. `cs::main` (in `lib/core.sh`):
+   - parses global flags: `--profile <name>`, `--config <path>`,
+     `--verbose`, `--dry-run`, `--help`, `--version`,
+   - loads config via `cs::fn::load_config` (precedence: CLI flag >
+     env > file),
+   - resolves the active profile via `cs::fn::resolve_profile`,
+   - dispatches via `cs::loader::dispatch`.
+3. `cs::loader::dispatch` (in `lib/loader.sh`):
+   - takes `<subcommand> [args...]`,
+   - sources `${LIB_DIR}/commands/cmd_<subcommand>.sh` on demand,
+   - calls `cs::cmd::<subcommand> "$@"`,
+   - emits a three-part error with suggestions if the command is unknown.
+4. **Bare invocation** (`claude-session` with no subcommand) dispatches to
+   `cs::cmd::run`, forwarding any remaining args to the real `claude`
+   binary. A `--` separator between wrapper flags and `claude` args is
+   recommended for clarity but not required.
+
+Startup is O(1) regardless of how many subcommands exist: only the file
+for the actual dispatched command is sourced.
+
+## Session-dir lifecycle (the `run` subcommand)
+
+This is the core behavior — the reason `claude-session` exists. All
+values that would be organization-specific are exposed as config /
+env variables (see [config.md](config.md)).
+
+1. **Terminal ID** (`cs::fn::terminal_id`):
+   - Read `$(tty)`. Strip `/dev/`. Replace `/` with `-` → e.g. `pts-0`,
+     `tty1`.
+   - If no tty (non-interactive caller), fall back to `pid-$$`.
+
+2. **Secure base directory** (`cs::fn::session_dir`):
+   - Project root, in order of preference:
+     1. `$XDG_RUNTIME_DIR/claude-session/` — preferred. Systemd-managed,
+        ephemeral (cleared on logout), mode 700 by default. The XDG
+        spec defines no default for `XDG_RUNTIME_DIR`, so if it is
+        unset we move on rather than guess a path.
+     2. `${XDG_STATE_HOME:-$HOME/.local/state}/claude-session/` —
+        XDG-standard durable fallback. Used when `$XDG_RUNTIME_DIR` is
+        unset or fails validation (containers without `pam_systemd`,
+        restricted CI, etc.). The spec default
+        (`$HOME/.local/state`) is hardcoded as the fallback when
+        `XDG_STATE_HOME` itself is unset; no wrapper-specific override
+        env var is exposed.
+   - No other fallback. No `/tmp`. If neither XDG path resolves, fail
+     with exit code 5.
+   - Both candidates are validated identically: must be a real
+     directory (not a symlink), owned by the current user. Mode is
+     forced to 700 before use.
+   - Sessions live under a `sessions/` subdir of the project root, so
+     sibling state (e.g. `install-manifest` in the state-home case,
+     future logs/caches) can coexist without colliding.
+   - Final session dir: `<root>/sessions/<terminal-id>` (mode 700).
+   - The resolved root and which source picked it (`runtime` vs
+     `state`) are recorded in `session-meta.json` and surfaced by
+     `claude-session doctor` so a fallback is never silent.
+
+3. **File classification**. Three handling modes for files/dirs the
+   upstream `~/.claude/` tree contains:
+
+   | Mode       | Example                                            | Why                                                                             |
+   |------------|----------------------------------------------------|---------------------------------------------------------------------------------|
+   | `sync`     | `.credentials.json`                                | Upstream rewrites atomically (temp + rename), which would break a symlink. Copy in at start, copy back on exit under `flock`. |
+   | `link`     | `settings.local.json`, `keybindings.json`, `CLAUDE.md` | Read-only or edited in place. Safe to symlink into the session dir.             |
+   | `dir-link` | `skills/`, `agents/`, `rules/`, `commands/`, `hooks/`  | Shared directories. Symlink the dir; rebuild the symlink if a previous run replaced it with a real dir. |
+
+   All three lists are overridable via env vars documented in
+   `docs/config.md`:
+   `CLAUDE_SESSION_SYNC_FILES`, `CLAUDE_SESSION_LINK_FILES`,
+   `CLAUDE_SESSION_LINK_DIRS` (colon-separated).
+
+4. **Settings merge** (`cs::fn::merge_settings`):
+   - If `$SHARED/settings.base.json` exists, build the session's
+     `settings.json`:
+     - If `$SHARED/settings.<profile>.json` exists, merge with
+       `jq -s '.[0] * .[1]' base profile > settings.json`.
+     - Otherwise copy base unchanged.
+   - Cache key: active profile name + base mtime + overlay mtime (if
+     any). Skip the merge if the cached output is still current. The
+     source script's cache logic is preserved verbatim.
+   - Profile overlays may also come from
+     `$XDG_CONFIG_HOME/claude-session/profiles/<name>.settings.json`,
+     in which case `$SHARED/settings.<profile>.json` is not required.
+
+5. **OAuth hook** (`cs::fn::run_hook` with `CLAUDE_SESSION_OAUTH_CMD`):
+   - Only runs if `CLAUDE_CODE_OAUTH_TOKEN` is not already set in the
+     environment.
+   - Runs the user-supplied command under a 5-second timeout.
+   - On success (non-empty stdout, non-whitespace), exports
+     `CLAUDE_CODE_OAUTH_TOKEN=<stdout>`.
+   - On failure, logs a warning to stderr (unless `--verbose`, in which
+     case it logs the full stderr of the hook) and proceeds.
+
+6. **Session metadata**:
+   - Write `<session-dir>/session-meta.json`, schema v1, containing:
+     `schema`, `profile`, `terminal_id`, `started_at` (ISO 8601 UTC),
+     `cwd`. Used by post-exit hooks.
+
+7. **Export** `CLAUDE_CONFIG_DIR=<session-dir>`.
+
+8. **Run** the real `claude` binary as a **child process, not via
+   `exec`** so that the EXIT trap fires. The child inherits the
+   terminal (stdin/stdout/stderr/signals work as expected).
+
+9. **On exit** (trap on `EXIT INT TERM`):
+   - `cs::fn::sync_files` copies each `sync`-classified file back to
+     the shared dir under `flock` (atomic temp + rename). Skip if the
+     session copy is older than the shared copy (another terminal
+     wrote more recently).
+   - Run `CLAUDE_SESSION_POST_EXIT_CMD` if set; the command gets
+     `CLAUDE_SESSION_DIR` and `CLAUDE_SESSION_PROFILE` in its env.
+     Hook failures do **not** change the wrapper's exit code (logged
+     only, unless `--verbose`).
+   - Exit with the real `claude` binary's status.
+
+10. **Signal mapping** (per bash-CLI convention): SIGINT → exit 130,
+    SIGTERM → exit 143.
+
+## Upstream `--bare` flag: OAuth is bypassed by design
+
+The upstream `claude --bare` mode (added in v2.1.81 for fast scripted
+`-p` calls) **deliberately disables OAuth and keychain auth**. It also
+skips hooks, LSP, plugin sync, and skill-directory walks. With `--bare`,
+the upstream binary requires an Anthropic API key via
+`ANTHROPIC_API_KEY` or via an `apiKeyHelper` defined in a `--settings`
+overlay; OAuth tokens in `.credentials.json` and the
+`CLAUDE_CODE_OAUTH_TOKEN` env var are intentionally ignored.
+
+This means the wrapper's OAuth hook (step 5 above) is effectively a
+no-op for `claude-session --bare …`: the session dir hydrates and the
+post-exit sync still works, but the child process will refuse the
+OAuth credential and report "Not logged in". This is upstream behavior,
+not a wrapper bug.
+
+Two supported ways to use `--bare` through `claude-session`:
+
+```sh
+# Inline API key via your secret store (gopass / pass / bw / op / …):
+ANTHROPIC_API_KEY="$(<your-key-lookup-cmd>)" \
+  claude-session --bare -p --model haiku "ping"
+
+# Or wire apiKeyHelper into a profile overlay so it is picked up by
+# the settings merge (cs::fn::merge_settings, step 4):
+#   $SHARED/settings.<profile>.json
+#   { "apiKeyHelper": "<your-key-lookup-cmd>" }
+```
+
+If you do **not** need `--bare`'s startup-time savings, drop the flag
+and the wrapper's normal OAuth flow works as documented:
+
+```sh
+claude-session -p --model haiku "ping"
+```
+
+A related upstream gotcha worth mentioning: issue #27900 reports the
+inverse — interactive mode ignoring `ANTHROPIC_API_KEY` and forcing
+`/login`. This is unrelated to `--bare` but sometimes surfaces when
+flipping profiles.
+
+References: upstream CLI reference and Authentication pages on
+`code.claude.com`; issue #36852 (`--bare` flag missing from docs);
+issue #27900 (interactive mode ignores `ANTHROPIC_API_KEY`).
+
+## Shared session-inventory rendering (`cs::fn::session_inventory`)
+
+`session list`, `session clean`, and `doctor` all surface the same
+sessions table (resolved parent + per-terminal rows). That rendering
+lives in **one** function — `cs::fn::session_inventory` — and is
+called from each of those subcommands. The function:
+
+1. Resolves the sessions parent (delegates to `cs::fn::session_dir`)
+   and reports which XDG source picked it (`runtime` / `state`).
+2. Walks `<root>/sessions/`, classifies each entry as active (owning
+   tty present) or stale, and collects size + mtime.
+3. Emits a deterministic table on stdout with optional flags
+   (`--no-header`, `--absolute`) honored uniformly across callers.
+
+This is the single source of truth for the "common ancestor at top,
+leaf rows below" shape. Adding a column or changing the sort order
+is a one-file edit; `doctor`'s overlap with `session list` is by
+construction, not by duplication.
+
+## Real-binary discovery (`cs::fn::real_claude`)
+
+Look up the path of the real `claude` binary, avoiding wrapper recursion.
+
+1. If `CLAUDE_SESSION_REAL_CLAUDE` is set and executable, use it.
+2. Else if `$HOME/.local/share/claude/versions/` exists (native install
+   layout), pick the highest-sorting entry (`sort -V | tail -n1`) that
+   is executable and does **not** resolve back to this wrapper.
+3. Else scan `PATH` entry by entry, skipping anything that resolves to
+   this wrapper.
+
+If none found, or if the candidate resolves back to this wrapper, emit a
+three-part error (exit code 4) with concrete remediation:
+`How to fix:` points at `claude login`, the native install path, and
+the `CLAUDE_SESSION_REAL_CLAUDE` override.
+
+## Strict mode
+
+```bash
+set -euo pipefail
+shopt -s inherit_errexit failglob nullglob
+```
+
+Known limits:
+
+- `set -e` is disabled inside `$(...)`, `if`/`&&`/`||` chains, and
+  `local var=$(...)`. For load-bearing logic prefer explicit
+  `|| cs::helpers::die` over implicit `set -e`.
+- Do **not** set `IFS=$'\n\t'` globally — quote everything and use
+  arrays instead.
+- `inherit_errexit` is guarded for bash < 4.4:
+  `shopt -s inherit_errexit 2>/dev/null || true`.
+
+Full rationale and references live in `docs/development.md` §"Strict
+mode policy".
+
+## stdout vs stderr
+
+- **stdout**: parseable data only (JSON when `--json` is implemented
+  later; stable text otherwise).
+- **stderr**: progress, warnings, logs, error messages including the
+  three-part error shape.
+- No ANSI escape codes on either stream unless `[[ -t 1 ]]` is true.
+- Use `printf '%s\n' ...` over `echo` (portable across bash versions).
+
+## Error shape
+
+Every failure path emits a three-part error on **stderr**, always
+paired with a non-zero exit code. Template:
+
+```
+Error: <one-line summary>
+
+What went wrong:
+  <1–3 lines of detail>
+
+How to fix:
+  <concrete command 1>
+  <concrete command 2>
+
+Next:
+  <optional follow-up hint>
+```
+
+The template is provided by `cs::fn::error` / `cs::helpers::die`.
+Agents rely on this shape to self-correct without prompting the user —
+don't skip parts or invent new ones.
+
+Exit code table (stable contract; agents may depend on it) lives in
+`docs/commands.md` §"Exit codes".
+
+## Temp files and signals
+
+Any session-dir creation pairs with a trap:
+
+```bash
+trap 'cs::fn::sync_files; cs::fn::run_hook "$CLAUDE_SESSION_POST_EXIT_CMD"' EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+```
+
+- Use single-quoted trap bodies (expansion happens at trap time, not
+  registration time).
+- `mktemp -d` for ephemeral scratch, always paired with a cleanup trap.
+
+## Data flow summary
+
+```
+  user invocation
+        │
+  bin/claude-session   ── sources ──▶ lib/{helpers,loader,core}.sh
+        │
+  cs::main             ── dispatches to ──▶ cs::cmd::<sub>
+        │
+  cs::cmd::run         ── uses ──▶ cs::fn::{terminal_id, session_dir,
+        │                                    merge_settings, sync_files,
+        │                                    link_files, real_claude,
+        │                                    run_hook}
+        │
+  exec child: real claude
+        │
+  EXIT trap            ── sync_files → run_hook(POST_EXIT_CMD) → exit child status
+```

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,0 +1,562 @@
+# Commands
+
+Every subcommand `claude-session` ships in v1, documented using the same
+template as each command's own `--help` output. This file is the
+canonical source for the user-facing contract: agents and scripts may
+rely on the exit codes, flag names, and output shape documented here.
+
+## Command tree
+
+```
+claude-session
+├── run [--profile <n>] [--dry-run] [-- <claude_args>...]
+├── doctor [--verbose]
+├── usage
+├── config
+│   ├── show
+│   ├── path
+│   └── edit
+├── profile
+│   ├── list
+│   └── show <name> [--verbose]
+└── session
+    ├── list
+    └── clean [--older-than <duration>] [--dry-run] [--yes]
+```
+
+`claude-session` with **no subcommand** dispatches to `run`, forwarding
+any remaining arguments to the real `claude` binary. A `--` separator
+is recommended but not required.
+
+Example:
+
+```sh
+claude-session --profile work -- chat "hello"
+```
+
+## Global flags
+
+These are parsed before subcommand dispatch and apply to every command.
+
+| Flag                          | Meaning                                                                  |
+|-------------------------------|--------------------------------------------------------------------------|
+| `--profile <name>`            | Override `CLAUDE_SESSION_PROFILE` for this invocation.                   |
+| `--config <path>`             | Override the config-file path (defaults to `$XDG_CONFIG_HOME/claude-session/config.env`). |
+| `--verbose`                   | Enable stderr debug logging. Equivalent to `CLAUDE_SESSION_VERBOSE=1`.   |
+| `--dry-run`                   | Where supported by a subcommand, show what would happen without acting.  |
+| `--help`, `-h`                | Show help for the invoked command and exit 0.                            |
+| `--version`                   | Print version string and exit 0.                                         |
+
+## Exit codes
+
+Stable contract. Agents and scripts may depend on these.
+
+| Code | Meaning                                                                                  |
+|------|------------------------------------------------------------------------------------------|
+| `0`  | Success.                                                                                 |
+| `1`  | Generic error (fallback).                                                                |
+| `2`  | Usage error — bad flag, unknown subcommand, missing required argument.                   |
+| `3`  | Config missing or invalid (syntax error, unreadable, not found when required).           |
+| `4`  | Real `claude` binary not found (or discovery resolved back to this wrapper).             |
+| `5`  | Secure session-dir validation failed: neither `XDG_RUNTIME_DIR` nor the `XDG_STATE_HOME` fallback resolved a usable, owner-correct, non-symlink directory. |
+| `6`  | Profile not found — name passed via `--profile` / `CLAUDE_SESSION_PROFILE` has no file.  |
+| `7`  | Hook command (`OAUTH_CMD` or `POST_EXIT_CMD`) failed in a path where failure is fatal.   |
+| `130`| Interrupted by SIGINT (128 + 2).                                                         |
+| `143`| Terminated by SIGTERM (128 + 15).                                                        |
+
+Codes 8–127 are reserved for future domain errors. Codes above 128 are
+reserved for signal-based exits (POSIX convention).
+
+---
+
+## Per-subcommand reference
+
+### `claude-session run`
+
+The default. Wraps the real `claude` binary with a per-terminal
+isolated `CLAUDE_CONFIG_DIR`.
+
+```
+USAGE:
+  claude-session run [--profile <name>] [--dry-run] [-- <claude_args>...]
+  claude-session [<claude_args>...]                 # bare form; `run` is default
+
+DESCRIPTION:
+  Create (or reuse) a session directory for the current terminal, merge
+  settings overlays for the active profile, symlink shared config, run
+  the optional OAuth hook, and exec the real claude binary as a child
+  process. On exit, sync back copy-classified files and run the
+  optional post-exit hook.
+
+FLAGS:
+  --profile <name>   Active profile. Overrides CLAUDE_SESSION_PROFILE.
+  --dry-run          Print the plan (session dir, merged settings path,
+                     hooks to run, final claude invocation) and exit 0
+                     without invoking claude.
+
+EXAMPLES:
+  claude-session run
+  claude-session --profile vertex run
+  claude-session run -- chat "summarize today's commits"
+  claude-session --dry-run run
+
+EXIT CODES:
+  0    claude binary exited successfully
+  1    generic error
+  3    config invalid
+  4    real claude binary not found
+  5    secure-dir validation failed
+  6    profile not found
+  7    mandatory OAuth hook failed and no token available
+  130  SIGINT
+  143  SIGTERM
+  *    anything else is the real claude's exit code, forwarded unchanged
+
+OUTPUT (success):
+  stdout/stderr from the real claude are forwarded unchanged.
+
+OUTPUT (error, example):
+  Error: real claude binary not found.
+
+  What went wrong:
+    Searched $HOME/.local/share/claude/versions/ and PATH; no executable
+    named "claude" that does not resolve to this wrapper.
+
+  How to fix:
+    Install via:                claude install
+    Or set an override:         CLAUDE_SESSION_REAL_CLAUDE=/path/to/claude
+
+  Next:
+    claude-session doctor
+
+SEE ALSO:
+  claude-session doctor
+  claude-session profile show <name>
+  docs/architecture.md §"Session-dir lifecycle"
+```
+
+### `claude-session doctor`
+
+Structured health check. Run this first when something goes wrong.
+
+```
+USAGE:
+  claude-session doctor [--verbose]
+
+DESCRIPTION:
+  The verbose debug interface for the wrapper. Bundles every
+  health check (config presence and permissions, shared dir
+  accessibility, active profile validity, real-binary discovery,
+  hook invocability, session-dir resolution) AND the full session
+  inventory in one call, so a user or agent has a single command
+  to dump for triage.
+
+  Prints one line per check with an OK / WARN / FAIL status, then
+  a "Sessions" block — produced by the shared
+  `cs::fn::session_inventory` helper, the same renderer
+  `session list` uses — keyed by the resolved sessions parent
+  (common ancestor surfaced once, per-session rows underneath).
+  Closes with a "Next:" section listing remediation for any
+  non-OK check.
+
+  WARN is emitted when sessions resolve via the `XDG_STATE_HOME`
+  fallback so the downgrade is never silent.
+
+  The session block is intentionally identical to `session list`'s
+  output: doctor is the everything-at-once view, `session list` is
+  the parseable inventory in isolation. Both call the same renderer
+  — there is no duplicated code.
+
+FLAGS:
+  --verbose   Include resolved paths and the env vars the active
+              profile would set. Redaction rules in docs/config.md
+              apply (values of *_TOKEN / *_SECRET / *_KEY /
+              *_PASSWORD are printed as "<redacted>").
+
+EXAMPLES:
+  claude-session doctor
+  CLAUDE_SESSION_PROFILE=vertex claude-session doctor --verbose
+
+EXIT CODES:
+  0   all checks passed (or only WARNs, no FAILs)
+  1   one or more checks FAILed (details in output)
+  3   no config available and required checks cannot run
+
+OUTPUT (success, example — sessions on XDG_RUNTIME_DIR):
+  config          OK    /home/user/.config/claude-session/config.env (mode 600)
+  shared dir      OK    /home/user/.claude (exists, readable)
+  profile         OK    "default"
+  real claude     OK    /home/user/.local/share/claude/versions/1.2.3
+  oauth hook      —     CLAUDE_SESSION_OAUTH_CMD unset (skipped)
+  post-exit hook  —     CLAUDE_SESSION_POST_EXIT_CMD unset (skipped)
+  session root    OK    /run/user/1000/claude-session/  (XDG_RUNTIME_DIR, mode 700)
+
+  Sessions under /run/user/1000/claude-session/sessions/  (3 dirs: 1 active, 2 stale)
+    terminal_id   status   size      mtime
+    pts-0         active   412 KiB   2026-04-25T09:02:11Z
+    pts-3         stale    311 KiB   2026-04-24T14:17:42Z
+    pid-48221     stale    184 KiB   2026-04-23T22:01:09Z
+
+OUTPUT (fallback example — XDG_STATE_HOME):
+  ...
+  session root    WARN  /home/user/.local/state/claude-session/  (XDG_STATE_HOME fallback; XDG_RUNTIME_DIR unset)
+
+  Sessions under /home/user/.local/state/claude-session/sessions/  (1 dir: 1 active)
+    terminal_id   status   size      mtime
+    pts-0         active   188 KiB   2026-04-25T09:02:11Z
+
+  Next:
+    Restore the runtime dir:  loginctl enable-linger $USER  (or set XDG_RUNTIME_DIR)
+
+SEE ALSO:
+  claude-session config show
+  claude-session profile list
+  claude-session session list
+  docs/config.md
+```
+
+### `claude-session usage`
+
+Dump the entire command tree (flags, defaults, examples) in one call
+for ingestion by agents or for grep-able reference. This is the
+aggregate form Linearis / the internal agent-CLI reference recommend.
+
+```
+USAGE:
+  claude-session usage
+
+DESCRIPTION:
+  Print every subcommand's --help output concatenated in a
+  deterministic order, preceded by the command tree and the global
+  flags table. The output is plain text, no ANSI, stable across
+  patch releases. Agents can pipe this into context once and skip
+  per-subcommand --help calls.
+
+FLAGS:
+  (none)
+
+EXAMPLES:
+  claude-session usage
+  claude-session usage | grep -A 3 "EXIT CODES"
+
+EXIT CODES:
+  0   always (unless invoked with bad global flags, → 2)
+
+OUTPUT:
+  ~300–600 lines of plain text, grouped per subcommand.
+
+SEE ALSO:
+  claude-session --help
+  claude-session <cmd> --help
+```
+
+### `claude-session config show`
+
+Dump the effective, resolved config (file + env overrides) to stdout.
+
+```
+USAGE:
+  claude-session config show [--verbose]
+
+DESCRIPTION:
+  Print every CLAUDE_SESSION_* variable and its resolved value, one
+  per line as KEY=VALUE. Variables unset with no default appear with
+  a "(unset)" placeholder. Redaction (see docs/config.md
+  §"Secrets discipline") applies unless --verbose.
+
+FLAGS:
+  --verbose   Do not redact secret-like variable values.
+
+EXAMPLES:
+  claude-session config show
+  claude-session --profile work config show --verbose
+
+EXIT CODES:
+  0   success
+  3   config file exists but is syntactically invalid
+
+OUTPUT (example):
+  CLAUDE_SESSION_CONFIG_DIR=/home/user/.config/claude-session
+  CLAUDE_SESSION_SHARED_DIR=/home/user/.claude
+  CLAUDE_SESSION_PROFILE=work
+  CLAUDE_SESSION_REAL_CLAUDE=(unset, auto-discover)
+  CLAUDE_SESSION_OAUTH_CMD=<redacted>
+  CLAUDE_SESSION_POST_EXIT_CMD=my-cost-sync --session-dir "$CLAUDE_SESSION_DIR"
+  CLAUDE_SESSION_SYNC_FILES=.credentials.json
+  CLAUDE_SESSION_LINK_FILES=settings.local.json:keybindings.json:CLAUDE.md
+  CLAUDE_SESSION_LINK_DIRS=skills:agents:rules:commands:hooks
+  CLAUDE_SESSION_VERBOSE=0
+
+SEE ALSO:
+  claude-session config path
+  claude-session config edit
+  docs/config.md
+```
+
+### `claude-session config path`
+
+Print the resolved path of the main config file. Useful for scripts.
+
+```
+USAGE:
+  claude-session config path
+
+DESCRIPTION:
+  Print the full path to `config.env` that claude-session would load
+  given the current environment (honors --config, CLAUDE_SESSION_CONFIG_DIR,
+  and XDG_CONFIG_HOME). Always one line, always on stdout. Non-existent
+  files are still printed (the path is "what would be loaded"); exit 0.
+
+FLAGS:
+  (none)
+
+EXAMPLES:
+  claude-session config path
+  $EDITOR "$(claude-session config path)"
+
+EXIT CODES:
+  0   success
+
+OUTPUT (example):
+  /home/user/.config/claude-session/config.env
+
+SEE ALSO:
+  claude-session config edit
+```
+
+### `claude-session config edit`
+
+Open the main config file in `$EDITOR`, creating it if missing.
+
+```
+USAGE:
+  claude-session config edit
+
+DESCRIPTION:
+  Resolve the config-file path (as `config path` does), create the
+  parent directory and file (mode 600) if they do not exist, then
+  exec $EDITOR (or $VISUAL, or `vi` as the ultimate fallback) on it.
+
+FLAGS:
+  (none)
+
+EXAMPLES:
+  claude-session config edit
+  VISUAL=nvim claude-session config edit
+
+EXIT CODES:
+  0   editor exited normally
+  1   editor exited non-zero (forwarded)
+  3   parent directory could not be created
+
+OUTPUT:
+  Whatever the editor writes to the terminal. No output of our own.
+
+SEE ALSO:
+  claude-session config path
+  claude-session config show
+```
+
+### `claude-session profile list`
+
+List every profile discoverable under `$CLAUDE_SESSION_CONFIG_DIR/profiles/`.
+
+```
+USAGE:
+  claude-session profile list
+
+DESCRIPTION:
+  Enumerate profiles. A profile is any file matching
+  profiles/<name>.env (trailing .env is the marker). An optional
+  overlay profiles/<name>.settings.json may coexist. Output is one
+  profile name per line, sorted alphabetically. The active profile
+  (from --profile / CLAUDE_SESSION_PROFILE / default) is marked with
+  a leading "*" on that line.
+
+FLAGS:
+  (none)
+
+EXAMPLES:
+  claude-session profile list
+
+EXIT CODES:
+  0   success (including zero profiles — stdout is just empty)
+  3   profiles directory unreadable
+
+OUTPUT (example):
+  * default
+    experiment
+    vertex
+    work
+
+SEE ALSO:
+  claude-session profile show <name>
+  docs/config.md
+```
+
+### `claude-session profile show <name>`
+
+Dump one profile's resolved env vars.
+
+```
+USAGE:
+  claude-session profile show <name> [--verbose]
+
+DESCRIPTION:
+  Source profiles/<name>.env in an isolated subshell and print the
+  KEY=VALUE pairs it defines. Secret-like values are redacted unless
+  --verbose. If profiles/<name>.settings.json exists, its path is
+  printed as a trailing comment.
+
+FLAGS:
+  --verbose   Do not redact secret-like variable values.
+
+EXAMPLES:
+  claude-session profile show default
+  claude-session profile show vertex --verbose
+
+EXIT CODES:
+  0   success
+  3   profile file exists but is syntactically invalid
+  6   profile not found
+
+OUTPUT (example):
+  # profile: vertex
+  # source: /home/user/.config/claude-session/profiles/vertex.env
+  CLAUDE_CODE_USE_VERTEX=1
+  CLOUD_ML_REGION=us-central1
+  ANTHROPIC_VERTEX_PROJECT_ID=<redacted>
+  # overlay: /home/user/.config/claude-session/profiles/vertex.settings.json
+
+SEE ALSO:
+  claude-session profile list
+  claude-session config show
+```
+
+### `claude-session session list`
+
+Inventory active and stale session directories.
+
+```
+USAGE:
+  claude-session session list
+
+DESCRIPTION:
+  Walk the resolved sessions parent
+  ($XDG_RUNTIME_DIR/claude-session/sessions/, or the
+  $XDG_STATE_HOME/claude-session/sessions/ fallback) for
+  per-terminal session directories.
+
+  Output shape: a single header line printing the absolute parent
+  path (the common ancestor) and which XDG source resolved it,
+  followed by a column header and one row per directory. Each row
+  lists terminal_id, status (active if the owning tty still exists,
+  stale otherwise), size, and mtime — the path is implicit from the
+  header so rows stay short and aligned. Sorted by mtime descending.
+
+FLAGS:
+  --absolute       Print fully-qualified paths in the terminal_id
+                   column instead of the leaf basename. Useful when
+                   piping into `xargs rm -r` or other path-consuming
+                   tools.
+  --no-header      Suppress the parent-path header and the column
+                   header. Emit data rows only — the most stable
+                   shape for `awk` / `cut` pipelines.
+
+EXAMPLES:
+  claude-session session list
+  claude-session session list --no-header | awk '$2 == "stale"'
+  claude-session session list --absolute --no-header | awk '$2 == "stale" { print $1 }'
+
+EXIT CODES:
+  0   success (zero rows is still success)
+  3   base directory unreadable
+  5   no usable XDG session root (see `doctor`)
+
+OUTPUT (example, default):
+  /run/user/1000/claude-session/sessions/  (XDG_RUNTIME_DIR)
+  # terminal_id   status   size     mtime
+  pts-0           active   412 KiB  2026-04-24T18:03:11Z
+  pts-3           stale    311 KiB  2026-04-24T14:17:42Z
+  pid-48221       stale    184 KiB  2026-04-23T22:01:09Z
+
+OUTPUT (example, --no-header):
+  pts-0           active   412 KiB  2026-04-24T18:03:11Z
+  pts-3           stale    311 KiB  2026-04-24T14:17:42Z
+  pid-48221       stale    184 KiB  2026-04-23T22:01:09Z
+
+SEE ALSO:
+  claude-session session clean
+  claude-session doctor
+```
+
+### `claude-session session clean`
+
+Remove stale session directories.
+
+```
+USAGE:
+  claude-session session clean [--older-than <duration>] [--dry-run] [--yes]
+
+DESCRIPTION:
+  Remove session directories under the resolved sessions parent
+  ($XDG_RUNTIME_DIR/claude-session/sessions/, or the
+  $XDG_STATE_HOME/claude-session/sessions/ fallback) whose status
+  is "stale" per `session list`, and — when --older-than is set —
+  whose mtime is older than the given duration. Never removes
+  active session dirs. Prompts for confirmation unless --yes or
+  --dry-run.
+
+  Output mirrors `session list`'s shape: the resolved parent path
+  is printed once at the top as the common ancestor, then each
+  candidate is listed by terminal_id alone underneath.
+
+FLAGS:
+  --older-than <dur>   Only delete directories older than <dur>. Accepts
+                       "N[smhdw]" suffix syntax (30s, 15m, 2h, 7d, 4w).
+                       Default: no age threshold (any stale dir is a
+                       candidate).
+  --dry-run            Print what would be removed and exit 0 without
+                       deleting anything.
+  --yes                Skip the interactive confirmation. Required when
+                       stdin is not a TTY (non-interactive usage).
+
+EXAMPLES:
+  claude-session session clean --dry-run
+  claude-session session clean --older-than 7d --yes
+  claude-session session clean --yes
+
+EXIT CODES:
+  0   success
+  1   one or more directories could not be removed
+  2   missing --yes under non-interactive stdin
+  3   base directory unreadable
+  5   no usable XDG session root (see `doctor`)
+
+OUTPUT (example, --dry-run):
+  Would remove 2 stale session directories under
+  /run/user/1000/claude-session/sessions/:
+    pts-3       (2026-04-24, 311 KiB)
+    pid-48221   (2026-04-23, 184 KiB)
+
+  Next:
+    Remove them:  claude-session session clean --yes
+
+SEE ALSO:
+  claude-session session list
+  claude-session doctor
+```
+
+## Output shape conventions
+
+- Every command writes parseable data to stdout and logs / progress /
+  errors to stderr.
+- Success output for mutation commands ends with an optional `Next:`
+  block of 2–3 plausible follow-up commands, per the agent-CLI design
+  reference.
+- Error output (on stderr) follows the three-part shape:
+  `What went wrong:` / `How to fix:` / `Next:`. See
+  [architecture.md](architecture.md) §"Error shape".
+- No ANSI color unless `[[ -t 1 ]]` is true.
+- List commands are tabular and grep-friendly; the first line is a
+  `# header` comment when columns exist.

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,187 @@
+# Configuration
+
+`claude-session` draws its runtime settings from three sources. Every
+setting has exactly one way to set it at each layer — there are no
+duplicate concepts across CLI flags, env vars, and the config file.
+
+## Precedence
+
+Highest priority first:
+
+1. **CLI flags** (e.g. `--profile vertex`, `--config /path/to/config.env`).
+2. **Environment variables** (`CLAUDE_SESSION_*` — full list below).
+3. **Config file**: `$XDG_CONFIG_HOME/claude-session/config.env`
+   (dotenv-style; overridable via `CLAUDE_SESSION_CONFIG_DIR` or the
+   `--config <path>` flag).
+
+This matches the convention documented in the internal agent-CLI design
+reference: flags > env > file.
+
+## File locations
+
+XDG-aware. The user install targets `$XDG_CONFIG_HOME` (defaulting to
+`$HOME/.config`); a system install uses `/etc/claude-session/`.
+
+| Path                                                                          | Purpose                                                                                                        |
+|-------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------|
+| `$XDG_CONFIG_HOME/claude-session/config.env`                                  | Main config. Dotenv: `KEY=VALUE` per line, `#` comments. Sourced at startup before profile resolution.         |
+| `$XDG_CONFIG_HOME/claude-session/profiles/<name>.env`                         | Per-profile overrides. Dotenv. Sourced **after** the main config, only if the named profile is active.         |
+| `$XDG_CONFIG_HOME/claude-session/profiles/<name>.settings.json`               | Optional JSON overlay for Claude's `settings.json`. Merged atop `$SHARED/settings.base.json` by `jq`.          |
+| `$CLAUDE_SESSION_SHARED_DIR/settings.base.json`                               | The Claude-side base settings the overlay extends. Lives in the user's shared Claude config dir (default `~/.claude`). Not created by `claude-session`. |
+| `$CLAUDE_SESSION_SHARED_DIR/settings.<profile>.json`                          | Alternative overlay location (legacy-compatible with the source script). Either location works; both are checked. |
+
+The whole config tree can be relocated by setting
+`CLAUDE_SESSION_CONFIG_DIR`. This is useful in sandboxed/devcontainer
+setups.
+
+## Config-file format
+
+Dotenv: `KEY=VALUE` per line, `#` introduces a line comment, blank lines
+are allowed. The file is sourced with `set -a; . "$file"; set +a` so
+every assignment becomes an environment variable, no `export` prefix
+required.
+
+**Do not** put shell logic in the config file (pipes, command
+substitutions, conditionals). It is meant as data. `claude-session`
+will load it under `set -a` only; complex initialization belongs in
+your shell rc.
+
+Minimal `config.env`:
+
+```
+CLAUDE_SESSION_PROFILE=default
+```
+
+A more realistic `config.env`:
+
+```
+CLAUDE_SESSION_PROFILE=work
+CLAUDE_SESSION_OAUTH_CMD=pass show <your-secret-path>
+CLAUDE_SESSION_POST_EXIT_CMD=my-cost-sync --session-dir "$CLAUDE_SESSION_DIR"
+```
+
+A profile file (`profiles/vertex.env`), with placeholders for values
+that must come from your own environment:
+
+```
+# Select Vertex AI backend for this profile.
+CLAUDE_CODE_USE_VERTEX=1
+CLOUD_ML_REGION=us-central1
+ANTHROPIC_VERTEX_PROJECT_ID=<your-gcp-project-id>
+```
+
+## Environment variable reference
+
+Every variable read by the CLI. Values marked `(unset)` disable the
+associated feature entirely.
+
+| Variable                          | Default                                                       | Meaning                                                                                                     |
+|-----------------------------------|---------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| `CLAUDE_SESSION_CONFIG_DIR`       | `$XDG_CONFIG_HOME/claude-session`                             | Where config files live. Overriding this moves `config.env` and `profiles/` as a group.                     |
+| `CLAUDE_SESSION_SHARED_DIR`       | `$HOME/.claude`                                               | The upstream Claude config dir being isolated. Files in here are what `settings` / `link` / `dir-link` lists point at. |
+| `CLAUDE_SESSION_PROFILE`          | `default`                                                     | Active profile name. Selects which `profiles/<name>.env` (and optional `<name>.settings.json`) to load.     |
+| `CLAUDE_SESSION_REAL_CLAUDE`      | (auto-discovered)                                             | Absolute path to the real `claude` binary. Overrides discovery; useful in devcontainers or CI.              |
+| `CLAUDE_SESSION_OAUTH_CMD`        | (unset)                                                       | Command whose stdout becomes `CLAUDE_CODE_OAUTH_TOKEN`, unless that var is already set. Run under a 5-second timeout. |
+| `CLAUDE_SESSION_POST_EXIT_CMD`    | (unset)                                                       | Command run after `claude` exits. Receives `CLAUDE_SESSION_DIR` and `CLAUDE_SESSION_PROFILE` in its env. Failures are logged, not fatal. |
+| `CLAUDE_SESSION_SYNC_FILES`       | `.credentials.json`                                           | Colon-separated list of files the upstream CLI may atomic-rewrite — copied in at start, synced back on exit under `flock`. |
+| `CLAUDE_SESSION_LINK_FILES`       | `settings.local.json:keybindings.json:CLAUDE.md`              | Colon-separated list of files safe to symlink into the session dir.                                         |
+| `CLAUDE_SESSION_LINK_DIRS`        | `skills:agents:rules:commands:hooks`                          | Colon-separated list of directories to symlink into the session dir.                                        |
+| `CLAUDE_SESSION_VERBOSE`          | `0`                                                           | `1` enables stderr debug logging (includes hook stderr, resolved paths, cache-hit reporting).               |
+
+The CLI also **forwards** any `CLAUDE_CODE_*` and `ANTHROPIC_*` env vars
+unchanged to the child process. That is how profile files inject
+`CLAUDE_CODE_USE_VERTEX`, `ANTHROPIC_VERTEX_PROJECT_ID`, etc.
+
+## Secrets discipline
+
+- **Never pass secrets as flags.** Flags are visible in `ps` output and
+  shell history. Use env vars or the config file instead.
+- **`chmod 600`** on your `config.env` and any `profiles/*.env` file
+  that contains a secret-store command or a token. `claude-session
+  doctor` warns if your config is world-readable.
+- The `CLAUDE_SESSION_OAUTH_CMD` pattern — delegating token lookup to a
+  user-provided command — is there so the token never lands on disk in
+  this CLI's files. Pair it with `pass`, `gopass`, `bw`, `op`, your
+  cloud secret manager, etc.
+- `claude-session profile show <name>` redacts values of any variable
+  whose name matches `*_TOKEN`, `*_SECRET`, `*_KEY`, `*_PASSWORD`
+  unless `--verbose` is passed.
+
+## Missing-config behavior
+
+- No `config.env` at all: treated as if the file is empty. Defaults
+  apply. `doctor` notes "no config file found" and points at the
+  expected path.
+- Missing `profiles/<name>.env` when an explicit profile was requested:
+  exit code 6 (profile not found) with a three-part error that lists
+  the profiles it did find and the search path it used. Example:
+
+  ```
+  Error: profile "vertex" not found.
+
+  What went wrong:
+    No file at /home/user/.config/claude-session/profiles/vertex.env
+    and no overlay at /home/user/.claude/settings.vertex.json.
+
+  How to fix:
+    List available profiles:  claude-session profile list
+    Create the profile:       $EDITOR /home/user/.config/claude-session/profiles/vertex.env
+
+  Next:
+    claude-session profile list
+  ```
+
+- Invalid dotenv syntax: exit code 3 with the offending line number.
+- `CLAUDE_SESSION_OAUTH_CMD` / `CLAUDE_SESSION_POST_EXIT_CMD` exit
+  non-zero: logged to stderr as a warning. Non-fatal for OAuth (token
+  just isn't set; user may already have it in env). Fatal (exit 7)
+  for `run` if the pre-start OAuth step fails **and** no token is
+  available from any source.
+
+## Migration from single-script predecessors
+
+If you are coming from a single-binary wrapper that hard-coded an
+OAuth-token source, a cost-sync tool, or a named Vertex AI profile,
+reproduce the old behavior by wiring a hook command and a named
+profile:
+
+```
+# Wire your own token-lookup command (pass, gopass, bw, op, etc.):
+CLAUDE_SESSION_OAUTH_CMD=<your-token-lookup-cmd>
+
+# Wire your own post-exit sync / analytics / cleanup:
+CLAUDE_SESSION_POST_EXIT_CMD=<your-post-exit-cmd>
+```
+
+And drop a profile file for the backend you want to switch into:
+
+```
+# ~/.config/claude-session/profiles/vertex.env
+CLAUDE_CODE_USE_VERTEX=1
+CLOUD_ML_REGION=<your-region>
+ANTHROPIC_VERTEX_PROJECT_ID=<your-gcp-project-id>
+```
+
+Activate with `--profile vertex` (or `CLAUDE_SESSION_PROFILE=vertex` in
+your shell rc).
+
+Invoke with `claude-session --profile vertex run …` (or set
+`CLAUDE_SESSION_PROFILE=vertex` in your shell rc).
+
+## Worked example: minimal to extensive
+
+**Barebones** — no `config.env`, no profile. `claude-session` uses the
+`default` profile (which does nothing) and behaves like a plain
+isolation wrapper.
+
+**One line** — `config.env` containing `CLAUDE_SESSION_PROFILE=work`,
+and `profiles/work.env` containing `ANTHROPIC_MODEL=claude-opus-4-7`.
+Now every invocation uses that model.
+
+**Full** — `config.env` sets `CLAUDE_SESSION_OAUTH_CMD` and
+`CLAUDE_SESSION_POST_EXIT_CMD`; `profiles/default.env` contains shared
+defaults; `profiles/{work,experiment,vertex}.env` contain per-profile
+overrides; `profiles/vertex.settings.json` adds a Claude Code-level
+overlay for the Vertex profile (for example, different permission
+presets). Switch profiles with `--profile <name>` or by setting
+`CLAUDE_SESSION_PROFILE` in a directory-scoped env file.

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,295 @@
+# Development
+
+Contributor / maintainer reference: how to set up the dev environment,
+what the coding rules are, how tests are structured, and what the
+release flow looks like. If you are writing code in this repo, read
+this and [`architecture.md`](architecture.md) first.
+
+## Prerequisites
+
+- bash 4.4+ (for `inherit_errexit`; macOS' system bash is 3.2, install
+  one from Homebrew).
+- [`bats-core`](https://bats-core.readthedocs.io/) — test runner.
+- [`shellcheck`](https://www.shellcheck.net/) — static analysis.
+- [`shfmt`](https://github.com/mvdan/sh) — formatter.
+- [`scdoc`](https://git.sr.ht/~sircmpwn/scdoc) — man page compiler.
+- `jq`, `flock` — runtime deps, but tests rely on them too.
+- `just` — recipe runner.
+- [`pre-commit`](https://pre-commit.com/) — lint orchestration.
+- `git` with submodule support.
+
+## Repo setup
+
+```sh
+git clone <url> claude-session
+cd claude-session
+git submodule update --init --recursive        # bats-support / -assert / -file
+pre-commit install                             # install the commit hook
+just check                                     # lint + test sanity
+```
+
+The bats helper libraries (`bats-support`, `bats-assert`, `bats-file`)
+are tracked as git submodules under `test/test_helper/`. They are
+required for every test file; check them out before running tests.
+
+## Strict mode policy
+
+Every entry-point bash file (currently just `bin/claude-session`) uses:
+
+```bash
+set -euo pipefail
+shopt -s inherit_errexit 2>/dev/null || true     # guarded for bash < 4.4
+shopt -s failglob nullglob
+```
+
+Documented caveats to watch for (and that reviewers will flag):
+
+- `set -e` is disabled inside `$(...)`, inside the LHS of `if` / `&&`
+  / `||` chains, and inside `local var=$(…)` (the `local` masks the
+  inner exit code). For load-bearing logic, prefer explicit `||
+  cs::helpers::die` over trusting implicit `set -e`.
+- `set -o pipefail` can turn a benign SIGPIPE (short-circuiting
+  `grep -q`) into a failure. Use `|| true` where the pipe is
+  intentionally short-circuited.
+- **Do not set `IFS=$'\n\t'`** globally. Always quote `"$@"` and
+  `"${arr[@]}"` and use arrays instead. This is a deliberate choice
+  — see the "bash strict mode critique" references in
+  [`architecture.md`](architecture.md) §"Strict mode".
+- `trap '…' EXIT INT TERM` with single-quoted bodies (variables
+  expand at trap time, not registration time).
+
+Library files under `lib/` do **not** set strict mode themselves — the
+entry point already did. They only need `# shellcheck shell=bash` at
+the top.
+
+## Shellcheck
+
+`.shellcheckrc` at repo root:
+
+```
+external-sources=true
+source-path=SCRIPTDIR
+source-path=SCRIPTDIR/lib
+shell=bash
+```
+
+Rules enforced on review:
+
+- Every cross-file `source` carries an explicit
+  `# shellcheck source=<path>` directive. Without it, shellcheck
+  silently skips the sourced file and misses half the real bugs.
+- Any `# shellcheck disable=SCxxxx` disable carries a one-line
+  justification comment. Unexplained disables fail review.
+- Warnings are errors in CI. Run `just lint` before pushing.
+
+## File header convention
+
+Every `.sh` under `lib/` starts with exactly two lines:
+
+```bash
+# shellcheck shell=bash
+: 'desc: One-sentence description of what this file defines.'
+```
+
+- No shebang — these files are sourced, not executed.
+- The `desc:` sentinel is harvested by the help/man generator (see the
+  `usage` subcommand implementation) and by the `# <cmd>` doc-comment
+  preamble in generated help output.
+- The description must be a single line and describe the **intent**,
+  not the implementation (e.g. "Dispatch a subcommand by sourcing the
+  matching file", not "Source lib/commands/cmd_$1.sh").
+
+## Naming convention
+
+| Path                         | Defines                            | Visibility |
+|------------------------------|------------------------------------|------------|
+| `bin/claude-session`         | Entry shim; sets up env, calls `cs::main`. | n/a    |
+| `lib/commands/cmd_<n>.sh`    | `cs::cmd::<n>`                     | public     |
+| `lib/functions/fn_<n>.sh`    | `cs::fn::<n>`                      | public     |
+| `lib/helpers.sh`             | `cs::helpers::*` utilities         | shared     |
+| `lib/loader.sh`              | `cs::loader::dispatch`             | internal   |
+| `lib/core.sh`                | `cs::main`                         | internal   |
+| (any file) `__<n>`           | Private, same-file only            | private    |
+
+**One public function per file** under `lib/commands/` and
+`lib/functions/`, with the filename mirroring the function name. The
+dispatcher (`cs::loader::dispatch`) derives the file path from the
+subcommand without a lookup table: `sub` → `lib/commands/cmd_${sub}.sh`.
+
+## Pre-commit hooks
+
+Hook list for `.pre-commit-config.yaml` (derived from the bash subset
+the repo owner uses across their other bash CLIs):
+
+- **standard** (`pre-commit/pre-commit-hooks`):
+  `trailing-whitespace`, `end-of-file-fixer`, `check-merge-conflict`,
+  `check-yaml`, `check-executables-have-shebangs`,
+  `check-shebang-scripts-are-executable`.
+- **shellcheck** (`koalaman/shellcheck-precommit` or `shellcheck-py`):
+  `--severity=warning`.
+- **shfmt** (`mvdan/sh` pre-commit mirror):
+  `-i 2 -ci -w` (2-space indent, compact if-else, write in place).
+
+Run locally:
+
+```sh
+just lint              # pre-commit run --all-files
+```
+
+Never invoke `shellcheck`, `shfmt`, or any other linter directly —
+always through `pre-commit`. This keeps one source of truth for config
+and prevents drift between developers.
+
+## Tests
+
+### Layout
+
+```
+test/
+├── test_helper.bash                      # common setup; loads bats-*, sets PATH
+├── test_helper/
+│   ├── bats-support/                     # submodule
+│   ├── bats-assert/                      # submodule
+│   └── bats-file/                        # submodule
+├── cmd_run_test.bats
+├── cmd_doctor_test.bats
+├── cmd_config_test.bats
+├── cmd_profile_test.bats
+├── cmd_session_test.bats
+├── fn_real_claude_test.bats
+├── fn_session_dir_test.bats
+├── fn_merge_settings_test.bats
+├── fn_terminal_id_test.bats
+└── fn_sync_files_test.bats
+```
+
+Filename convention: `<module>_test.bats` (suffix, not prefix).
+
+### `test_helper.bash`
+
+```bash
+_common_setup() {
+  load 'test_helper/bats-support/load'
+  load 'test_helper/bats-assert/load'
+  load 'test_helper/bats-file/load'
+  PATH="${BATS_TEST_DIRNAME}/../bin:$PATH"
+}
+```
+
+Per-test setup:
+
+```bash
+setup() {
+  load 'test_helper'
+  _common_setup
+}
+```
+
+### Tagging unit vs integration
+
+Bats supports inline tags:
+
+```bash
+# bats test_tags=unit
+@test "fn_terminal_id handles missing tty" {
+  …
+}
+
+# bats test_tags=integration
+@test "run creates session dir and invokes claude" {
+  …
+}
+```
+
+- **Unit** tests: no filesystem side effects beyond `BATS_TEST_TMPDIR`,
+  no subprocess calls to the real `claude` binary. Fast; run on every
+  commit.
+- **Integration** tests: may create real session dirs, merge settings
+  via `jq`, exercise the full dispatch path. Use a mocked `claude`
+  stub via `$CLAUDE_SESSION_REAL_CLAUDE` pointing at a test-local
+  fake binary.
+
+Run via `just test-unit`, `just test-integration`, or `just test` for
+both.
+
+## CI matrix
+
+Minimum viable GitHub Actions matrix:
+
+```yaml
+jobs:
+  check:
+    strategy:
+      matrix:
+        bash: ['4.4', '5.0', '5.2']
+    steps:
+      - uses: actions/checkout@v4
+        with: { submodules: recursive }
+      - run: just lint
+      - run: just test
+```
+
+One job per bash version. Submodules are recursive (bats helpers).
+The single gate is `just check`.
+
+## Commit style
+
+[Conventional Commits](https://www.conventionalcommits.org/). Scopes
+should map to either a subcommand (`cmd_doctor`, `cmd_run`), a function
+(`fn_real_claude`), or an area (`install`, `docs`, `ci`). Examples:
+
+```
+feat(cmd_session): add --older-than duration flag
+fix(fn_real_claude): skip PATH entries that resolve back to wrapper
+docs(config): document CLAUDE_SESSION_SYNC_FILES default
+chore(ci): add bash 5.2 to matrix
+```
+
+Breaking changes carry a `!` and a `BREAKING CHANGE:` footer.
+
+## Agent-surface checklist
+
+Applied during PR review for any change touching subcommands:
+
+- [ ] Each subcommand has complete `--help` (flags, defaults, examples,
+      exit codes, `SEE ALSO`).
+- [ ] `usage` aggregate output regenerates cleanly.
+- [ ] Error paths emit the three-part shape
+      (`What went wrong:` / `How to fix:` / `Next:`).
+- [ ] Exit codes match the table in
+      [`commands.md`](commands.md) §"Exit codes".
+- [ ] `doctor` covers any new external dependency or env var.
+- [ ] stdout stays parseable; all logging / progress goes to stderr.
+- [ ] No ANSI escape codes unless `[[ -t 1 ]]`.
+- [ ] Config precedence is `flags > env > file`.
+- [ ] No interactive prompt when `[[ ! -t 0 ]]` — fail with remediation.
+- [ ] Destructive ops have `--dry-run` and require `--yes` when stdin
+      isn't a tty.
+
+## Release flow
+
+1. Tag `vX.Y.Z` on `main`, following semver.
+2. CI runs `just check` against the tag on all supported bash versions.
+3. Update the `CHANGELOG.md` (Keep a Changelog format) before cutting
+   the tag.
+4. Publish a GitHub release with the changelog entry as the body.
+
+Package distribution (Homebrew formula, AUR `PKGBUILD`, Nix flake,
+`.deb`) is deliberately out of scope for v1; v1 ships as
+multi-file + `install.sh` via `just install`. Distribution targets are
+tracked as issues and picked up post-v1.
+
+## Style references
+
+Three external documents shape the style in this repo. Read them if
+you are doing non-trivial work:
+
+- The internal bash-CLI layout reference — directory shape, strict
+  mode, ShellCheck discipline, bats layout, XDG install.
+- The internal agent-CLI design reference — per-subcommand `--help`,
+  `usage`, `doctor`, error shape, config precedence, stdout/stderr
+  discipline, exit codes.
+- The internal bash-package `CLAUDE.md` — one-public-function-per-file
+  pattern, `__` prefix for privates, linting through pre-commit only.
+
+These are also summarized in [`AGENTS.md`](../AGENTS.md).

--- a/docs/features.md
+++ b/docs/features.md
@@ -1,0 +1,122 @@
+# Features
+
+The v1 feature inventory, organized by provenance: features **ported**
+verbatim (semantically) from the source script, features **generalized**
+(the source hard-coded a value; v1 makes it configurable), and features
+**added** from the internal agent-CLI design reference. A final section
+lists what is explicitly **deferred** beyond v1.
+
+## Ported from the source wrapper
+
+Eight core behaviors carry over unchanged in intent; see
+[architecture.md](architecture.md) §"Session-dir lifecycle" for the
+step-by-step.
+
+1. **Per-terminal `CLAUDE_CONFIG_DIR` isolation**, keyed by the caller's
+   `tty` path (`pts/0` → `pts-0`), with PID fallback when no tty is
+   attached. Each terminal gets an independent history, todos, projects,
+   and plans.
+2. **Secure session directory selection**: project root is
+   `$XDG_RUNTIME_DIR/claude-session/` when available, falling back to
+   `${XDG_STATE_HOME:-$HOME/.local/state}/claude-session/` — both
+   XDG-standard locations, with the spec default hardcoded when the
+   env var is unset. No `/tmp` fallback, no wrapper-specific override
+   vars. If neither XDG path is usable the wrapper fails fast with
+   exit code 5. Strict validation rejects symlinks, non-directories,
+   and wrong ownership; mode is forced to 700. Per-terminal sessions
+   land under a `sessions/` subdir of that root.
+3. **Profile-based `settings.json` overlay** via `jq -s '.[0] * .[1]'`,
+   with mtime-based cache invalidation so repeat invocations are fast
+   when nothing changed.
+4. **File classification** — three modes (`sync` / `link` / `dir-link`)
+   for files the wrapper stages into the session directory. The `sync`
+   mode's copy + atomic `flock`ed temp-rename pattern is preserved as
+   it was written in the source.
+5. **Real-binary discovery** prefers the native install path at
+   `$HOME/.local/share/claude/versions/` (highest `sort -V`), falling
+   back to a `PATH` scan that skips entries resolving back to this
+   wrapper. Recursion detection is fatal with remediation.
+6. **Session metadata** written as `session-meta.json` (schema v1,
+   `profile`, `terminal_id`, `started_at`, `cwd`) so post-exit hooks
+   have durable context.
+7. **Trap-based exit sync** under `flock`: `sync`-classified files are
+   atomically copied back to the shared dir on EXIT, skipping when the
+   shared copy is newer (another terminal wrote more recently).
+8. **Child-process execution** of the real `claude` binary (not `exec`)
+   so the EXIT trap runs and post-exit hooks fire.
+
+## Generalized (was hard-coded; now user-settable)
+
+The source script baked in values that are specific to a single user's
+environment. In v1 every one of them is exposed as a config / env
+variable so the repo can ship publicly with zero personal data.
+
+| Concept                                           | v1 surface                                                            |
+|---------------------------------------------------|-----------------------------------------------------------------------|
+| Switch backend (e.g. Vertex AI vs default)        | User-defined profiles under `~/.config/claude-session/profiles/`, selected via `--profile` / `CLAUDE_SESSION_PROFILE`. |
+| Cloud project ID                                  | User sets `ANTHROPIC_VERTEX_PROJECT_ID` (or equivalent) in their own `profiles/<name>.env`. |
+| Cloud region                                      | User sets `CLOUD_ML_REGION` (or equivalent) in their own `profiles/<name>.env`. |
+| Profile naming                                    | Any name; the built-in default is literally `default`. Examples in docs use generic names: `default`, `work`, `experiment`, `vertex`. |
+| Pre-startup OAuth-token lookup                    | Any command, via `CLAUDE_SESSION_OAUTH_CMD`. Unset → step skipped.    |
+| Post-exit cost-sync / analytics / cleanup         | Any command, via `CLAUDE_SESSION_POST_EXIT_CMD`. Unset → step skipped.|
+| Set of files to copy-sync vs symlink              | Overridable via `CLAUDE_SESSION_SYNC_FILES`, `CLAUDE_SESSION_LINK_FILES`, `CLAUDE_SESSION_LINK_DIRS`. |
+
+Migration path for users of the original script is documented in
+[config.md](config.md) §"Migration note".
+
+## New in v1 (agent-CLI surface)
+
+The source script is a single opaque binary — either it works or it
+fails silently. v1 adds the minimum set of CLI ergonomics from the
+internal agent-friendly-CLI design reference, so the tool is usable by
+both humans and LLM coding agents.
+
+- **`doctor` subcommand**: structured health check of config file
+  presence, shared dir accessibility, real-binary discovery, profile
+  validity, and hook invocability. Agents run this first when things
+  go sideways.
+- **`usage` subcommand**: dumps the entire command tree (flags,
+  defaults, examples) in one call — agents pipe it into context once
+  and avoid walking `--help` per subcommand.
+- **`config show | path | edit`**: inspect the active config,
+  resolve the config-file path (honoring
+  `CLAUDE_SESSION_CONFIG_DIR`), or open it in `$EDITOR`.
+- **`profile list | show <name>`**: enumerate profiles or dump one
+  profile's resolved env-var set (secrets redacted unless
+  `--verbose`).
+- **`session list | clean`**: list active / stale session
+  directories, clean with `--older-than <duration>` and `--dry-run`
+  / `--yes` guards.
+- **Per-subcommand `--help`** with USAGE / DESCRIPTION / FLAGS /
+  EXAMPLES / EXIT CODES / SEE ALSO sections, per the CLI-design
+  reference. Source of truth for the command contract.
+- **Three-part error shape** on every failure path: `What went
+  wrong:` / `How to fix:` / `Next:`. Template in
+  [architecture.md](architecture.md) §"Error shape".
+- **Stable exit codes** (contract for agents): 0 success, 1 generic,
+  2 usage, 3 config, 4 binary-not-found, 5 secure-dir-failure, 6
+  profile-not-found, 7 hook-failure, 130/143 for SIGINT/SIGTERM.
+  Full table in [commands.md](commands.md) §"Exit codes".
+- **stdout vs stderr discipline**: data on stdout, everything else on
+  stderr. No ANSI on non-tty output.
+- **`--dry-run` on destructive operations** (`session clean`).
+- **No interactive prompts** when stdin is not a tty — fail fast with
+  remediation instead.
+
+## Deferred to v1.1+
+
+These are planned but explicitly out of scope for v1 to keep the first
+release shippable.
+
+- `--json` on every read command (full JSON contract, versioned schema).
+- `schema <type>` subcommand — print JSON Schema for `session`,
+  `profile`, and the error envelope.
+- `verify` / `validate` loops for agent use (dry-run → verify → commit
+  pattern).
+- Cross-agent `SKILL.md` package (lives in a separate repo; symlinked
+  into `~/.claude/skills/` and `.agents/skills/`).
+- MCP shim over the CLI (only if someone actually needs it; the CLI
+  surface is intentionally the primary contract).
+- Homebrew / AUR / Nix packaging. v1 ships multi-file + `install.sh`
+  via `just install` only.
+- `systemd --user` timer for automated stale-session cleanup.

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,0 +1,145 @@
+# Install
+
+`claude-session` installs as a multi-file layout: a shim in `bin/` plus
+a `lib/` tree, a completions script, and a man page. The `justfile`
+orchestrates install, uninstall, test, lint, and man-page build.
+
+## Install matrix
+
+XDG-aware, `PREFIX`-overridable. The **user** column is the default
+(no `PREFIX`); the **system** column kicks in when `PREFIX` is set
+(e.g. `PREFIX=/usr/local`).
+
+| Artifact          | User                                                   | System                                                    |
+|-------------------|--------------------------------------------------------|-----------------------------------------------------------|
+| binary            | `$HOME/.local/bin/claude-session`                      | `$PREFIX/bin/claude-session`                              |
+| lib tree          | `$HOME/.local/lib/claude-session/`                     | `$PREFIX/lib/claude-session/`                             |
+| bash completion   | `$XDG_DATA_HOME/bash-completion/completions/`          | `$(pkg-config --variable=completionsdir bash-completion)` |
+| man page          | `$XDG_DATA_HOME/man/man1/claude-session.1`             | `$PREFIX/share/man/man1/claude-session.1`                 |
+| config            | `$XDG_CONFIG_HOME/claude-session/config.env`           | `/etc/claude-session/config.env`                          |
+| state             | `${XDG_STATE_HOME:-$HOME/.local/state}/claude-session/` | `/var/lib/claude-session/`                                |
+
+- User-install detection: `[[ $EUID -ne 0 && -z "$PREFIX" ]]`.
+- `install.sh` writes a manifest at
+  `${XDG_STATE_HOME:-$HOME/.local/state}/claude-session/install-manifest`
+  (or `/var/lib/claude-session/install-manifest` for system installs)
+  containing every path it copied. `uninstall.sh` reads this manifest
+  and removes exactly those paths; it never deletes user config or
+  session state.
+- The state dir doubles as the XDG-spec session-root fallback when
+  `XDG_RUNTIME_DIR` is unset. Sessions live in a `sessions/` subdir
+  there and are ignored by uninstall (see "Manifest-based uninstall"
+  below).
+
+## Prerequisites
+
+- bash 4.4+ (for `inherit_errexit`).
+- `jq` — settings-overlay merge at runtime.
+- `flock` — exit-time sync safety under concurrent terminals.
+- `just` — recipe orchestration. Optional for install (`install.sh`
+  works standalone), required for the test/lint workflow.
+- `scdoc` — only needed when building the man page (`just man`).
+
+## Recipes
+
+The `justfile` is the only supported entry point for
+build/test/lint/install operations. Its recipes:
+
+| Recipe                                  | Purpose                                                                                                                    |
+|-----------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
+| `just` (no args; default)               | `@just --list` — print recipe names with their doc-comments. Matches the convention used across the repo owner's other CLIs. |
+| `just install`                          | Run `install.sh` for user scope (`$HOME/.local/...`). Writes install manifest.                                             |
+| `just install PREFIX=/usr/local`        | System install under `$PREFIX`. Usually run with `sudo`.                                                                  |
+| `just uninstall`                        | Read the install manifest, remove every path it lists. Warn if the manifest is missing.                                   |
+| `just test`                             | Run unit **and** integration tests (`just test-unit && just test-integration`).                                            |
+| `just test-unit`                        | `bats --filter-tags 'unit,!integration' test/`.                                                                           |
+| `just test-integration`                 | `bats --filter-tags integration test/`.                                                                                   |
+| `just lint`                             | `pre-commit run --all-files`. Never invoke shellcheck/shfmt directly — always through pre-commit.                         |
+| `just check`                            | `just lint && just test`. The gate CI runs.                                                                                |
+| `just man`                              | `scdoc < man/claude-session.1.scd > man/claude-session.1`.                                                                 |
+| `just completions`                      | Copy `completions/claude-session.bash` to the target completions dir (honors user vs system install).                      |
+| `just clean`                            | Remove generated artifacts (`man/*.1` built output, bats tempdirs). Does **not** touch anything installed outside the repo. |
+
+Style conventions:
+
+- Recipe names: lowercase, hyphenated. No camelCase.
+- Each recipe has a single-line `#` doc-comment above it — that is
+  what `just --list` shows.
+- Destructive recipes carry an inline comment calling out the blast
+  radius.
+
+Example `just --list` output:
+
+```
+Available recipes:
+    check                   # run lint + test (CI gate)
+    clean                   # remove generated artifacts (non-destructive)
+    completions             # install bash completions
+    install PREFIX=""       # install claude-session (user scope if PREFIX empty)
+    lint                    # run pre-commit on all files
+    man                     # build man page via scdoc
+    test                    # run unit + integration tests
+    test-integration        # run integration bats tests
+    test-unit               # run unit bats tests
+    uninstall               # remove files listed in the install manifest
+```
+
+## Manifest-based uninstall
+
+`install.sh` records every destination path into
+`${XDG_STATE_HOME:-$HOME/.local/state}/claude-session/install-manifest`
+(one absolute path per line). `uninstall.sh`:
+
+1. Reads the manifest.
+2. Removes each listed path in reverse order (files, then directories).
+3. Only `rmdir`s directories — never `rm -rf` — so a user-created file
+   dropped into an install dir prevents deletion and is preserved.
+4. Removes the manifest itself last.
+5. Does **not** touch `$XDG_CONFIG_HOME/claude-session/` (user
+   config) or any `sessions/` subdir under
+   `${XDG_STATE_HOME:-$HOME/.local/state}/claude-session/` — that
+   subdir is the XDG-state fallback session root, populated only
+   when `XDG_RUNTIME_DIR` was unavailable, and may contain live
+   session state. The install manifest itself lives at
+   `${XDG_STATE_HOME:-$HOME/.local/state}/claude-session/install-manifest`
+   and is removed last.
+
+If the manifest is missing, `uninstall.sh` logs a warning with the
+expected path and exits 1 (per the standard exit-code contract in
+[commands.md](commands.md)).
+
+## Post-install setup
+
+After `just install`, suggest adding to the user's shell rc:
+
+```sh
+# alias claude to the wrapper for automatic per-terminal isolation
+alias claude='claude-session run'
+
+# enable bash completion (if completions dir is not auto-sourced)
+# shellcheck disable=SC1091
+. "${XDG_DATA_HOME:-$HOME/.local/share}/bash-completion/completions/claude-session.bash"
+```
+
+Then:
+
+```sh
+claude-session config edit        # create your config.env interactively
+claude-session doctor             # verify everything resolves
+```
+
+## PATH note
+
+`$HOME/.local/bin` is the user-install bin directory. If it is not
+already on `PATH`, `install.sh` prints a warning at the end with the
+exact line to add to the user's shell profile. This mirrors the
+behavior in the `devcontainerctl` reference installer.
+
+## Upgrading
+
+In-place upgrade: `git pull && just install`. `install.sh` overwrites
+existing files at the same paths and updates the manifest in place.
+Old files removed from the repo between versions are cleaned up by
+comparing the new installation's output against the previous manifest.
+
+For a clean slate, `just uninstall && just install`.


### PR DESCRIPTION
Closes #1

## Summary

Establishes foundational project structure for the `claude-session` bash CLI. Adds comprehensive documentation specs, development workflows, and pre-commit hooks to ensure code quality, security, and public-repo hygiene as the project scales.

## Key Changes

- **`.pre-commit-config.yaml`**: Comprehensive hook suite covering shell linting (ShellCheck, shfmt, bashate), secret scanning (gitleaks), commit message validation (gitlint, commitizen), and code quality checks. Configured with sane defaults for bash projects; meta hooks and bats tests are deferred until shell sources land.

- **`AGENTS.md`**: Cross-agent context defining project scope, tech stack (bash 4.4+, just, bats-core), build/test/lint commands, file structure conventions, and negative scope (no secrets, no org identifiers, deferred features).

- **`CLAUDE.md`**: Claude Code-specific guardrails documenting canonical design specs in `docs/`, pre-commit requirements, and hard rules for public-repo hygiene (no cloud project IDs, OAuth tokens, or personal identifiers).

- **`docs/` directory**: Architecture, commands, config, development, features, and install documentation establishing the design intent and developer workflow.

- **Updated `README.md`**: Reflects foundational project description and scaffolding.

The scaffolding enforces `just check` (lint + test) before commits and prevents accidental commits to protected branches, establishing baseline quality and security posture for ongoing development.