### PR TITLE
Solves issue "#3 Remove man page generation and git submodule dependencies"

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.{sh,bash,bats}]
+indent_size = 2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,11 @@ repos:
     hooks:
       - id: bashate
         args: ["-i", "E003,E006", "-e", "E005"]  # allow 2-space indent; error on tabs
-        exclude: ^test/(.*\.bats|test_helper(/.*|\.bash))$
+        exclude: >-
+          (?x)(
+          ^test/(.*\.bats|test_helper(/.*|\.bash))$
+          |^completions/.*\.bash$
+          )
 
   # Pre-commit hook to check for spelling mistakes
   - repo: https://github.com/crate-ci/typos

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,4 @@
+external-sources=true
+source-path=SCRIPTDIR
+source-path=SCRIPTDIR/lib
+shell=bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,15 +19,11 @@ variable.
 
 - **Language**: bash 4.4+ (`set -euo pipefail`, `shopt -s inherit_errexit`).
 - **Build / task runner**: [`just`](https://just.systems/) (see `justfile`).
-- **Tests**: [`bats-core`](https://bats-core.readthedocs.io/) with
-  `bats-support` / `bats-assert` / `bats-file` as git submodules under
-  `test/test_helper/`.
+- **Tests**: [`bats-core`](https://bats-core.readthedocs.io/).
 - **Linting**: [`shellcheck`](https://www.shellcheck.net/) and
   [`shfmt`](https://github.com/mvdan/sh), orchestrated through
   [`pre-commit`](https://pre-commit.com/). **Never invoke linters directly;
   always run them through pre-commit.**
-- **Man page**: [`scdoc`](https://git.sr.ht/~sircmpwn/scdoc) source in
-  `man/*.scd`, compiled to `.1` by `just man`.
 - **Runtime dependencies**: `jq` (settings overlay merge), `flock`
   (exit-time sync under lock).
 
@@ -45,7 +41,6 @@ Subsets:
 just test-unit         # fast bats unit tests
 just test-integration  # bats integration tests (touch filesystem)
 just lint              # pre-commit run --all-files
-just man               # build man page
 ```
 
 ## Where things live

--- a/bin/claude-session
+++ b/bin/claude-session
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s inherit_errexit 2>/dev/null || true
+shopt -s failglob nullglob
+
+SCRIPT_PATH="$(readlink -f "$0")"
+SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
+PREFIX_DIR="$(dirname "$SCRIPT_DIR")"
+LIB_DIR="$PREFIX_DIR/lib/claude-session"
+
+if [[ ! -d "$LIB_DIR" ]]; then
+  LIB_DIR="$PREFIX_DIR/lib"
+fi
+
+export CS_WRAPPER_PATH="$SCRIPT_PATH"
+export LIB_DIR
+
+# shellcheck source=lib/helpers.sh
+. "$LIB_DIR/helpers.sh"
+# shellcheck source=lib/loader.sh
+. "$LIB_DIR/loader.sh"
+# shellcheck source=lib/core.sh
+. "$LIB_DIR/core.sh"
+
+cs::main "$@"

--- a/completions/claude-session.bash
+++ b/completions/claude-session.bash
@@ -1,0 +1,46 @@
+# shellcheck shell=bash
+# bash completion for claude-session
+
+_claude_session() {
+  local cur prev words cword
+  COMPREPLY=()
+  cur=${COMP_WORDS[COMP_CWORD]}
+  prev=${COMP_WORDS[COMP_CWORD - 1]}
+  words=("${COMP_WORDS[@]}")
+  cword=$COMP_CWORD
+
+  local commands="run doctor usage config profile session"
+  local globals="--profile --config --verbose --dry-run --help --version"
+
+  if [[ $cword -eq 1 ]]; then
+    mapfile -t COMPREPLY < <(compgen -W "$globals $commands" -- "$cur")
+    return 0
+  fi
+
+  case "${words[1]}" in
+    config)
+      mapfile -t COMPREPLY < <(compgen -W "show path edit --help --verbose" -- "$cur")
+      ;;
+    profile)
+      mapfile -t COMPREPLY < <(compgen -W "list show --help --verbose" -- "$cur")
+      ;;
+    session)
+      if [[ "$prev" == "session" ]]; then
+        mapfile -t COMPREPLY < <(compgen -W "list clean --help" -- "$cur")
+      else
+        mapfile -t COMPREPLY < <(compgen -W "--absolute --no-header --older-than --dry-run --yes --help" -- "$cur")
+      fi
+      ;;
+    run)
+      mapfile -t COMPREPLY < <(compgen -W "--profile --dry-run --help --" -- "$cur")
+      ;;
+    doctor)
+      mapfile -t COMPREPLY < <(compgen -W "--verbose --help" -- "$cur")
+      ;;
+    *)
+      mapfile -t COMPREPLY < <(compgen -W "$globals $commands" -- "$cur")
+      ;;
+  esac
+}
+
+complete -F _claude_session claude-session

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -35,14 +35,8 @@ claude-session/
 │       └── fn_error.sh              # three-part error emitter
 ├── completions/
 │   └── claude-session.bash
-├── man/
-│   └── claude-session.1.scd         # scdoc source → claude-session.1
 ├── test/
-│   ├── test_helper.bash             # common setup; loads bats-* submodules
-│   ├── test_helper/
-│   │   ├── bats-support/            # submodule
-│   │   ├── bats-assert/             # submodule
-│   │   └── bats-file/               # submodule
+│   ├── test_helper.bash             # common setup
 │   ├── cmd_<name>_test.bats         # per-command tests
 │   └── fn_<name>_test.bats          # per-function tests
 ├── .shellcheckrc

--- a/docs/development.md
+++ b/docs/development.md
@@ -12,25 +12,18 @@ this and [`architecture.md`](architecture.md) first.
 - [`bats-core`](https://bats-core.readthedocs.io/) — test runner.
 - [`shellcheck`](https://www.shellcheck.net/) — static analysis.
 - [`shfmt`](https://github.com/mvdan/sh) — formatter.
-- [`scdoc`](https://git.sr.ht/~sircmpwn/scdoc) — man page compiler.
 - `jq`, `flock` — runtime deps, but tests rely on them too.
 - `just` — recipe runner.
 - [`pre-commit`](https://pre-commit.com/) — lint orchestration.
-- `git` with submodule support.
 
 ## Repo setup
 
 ```sh
 git clone <url> claude-session
 cd claude-session
-git submodule update --init --recursive        # bats-support / -assert / -file
 pre-commit install                             # install the commit hook
 just check                                     # lint + test sanity
 ```
-
-The bats helper libraries (`bats-support`, `bats-assert`, `bats-file`)
-are tracked as git submodules under `test/test_helper/`. They are
-required for every test file; check them out before running tests.
 
 ## Strict mode policy
 
@@ -146,11 +139,7 @@ and prevents drift between developers.
 
 ```
 test/
-├── test_helper.bash                      # common setup; loads bats-*, sets PATH
-├── test_helper/
-│   ├── bats-support/                     # submodule
-│   ├── bats-assert/                      # submodule
-│   └── bats-file/                        # submodule
+├── test_helper.bash                      # common setup, sets PATH
 ├── cmd_run_test.bats
 ├── cmd_doctor_test.bats
 ├── cmd_config_test.bats
@@ -169,9 +158,6 @@ Filename convention: `<module>_test.bats` (suffix, not prefix).
 
 ```bash
 _common_setup() {
-  load 'test_helper/bats-support/load'
-  load 'test_helper/bats-assert/load'
-  load 'test_helper/bats-file/load'
   PATH="${BATS_TEST_DIRNAME}/../bin:$PATH"
 }
 ```
@@ -224,13 +210,11 @@ jobs:
         bash: ['4.4', '5.0', '5.2']
     steps:
       - uses: actions/checkout@v4
-        with: { submodules: recursive }
       - run: just lint
       - run: just test
 ```
 
-One job per bash version. Submodules are recursive (bats helpers).
-The single gate is `just check`.
+One job per bash version. The single gate is `just check`.
 
 ## Commit style
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,8 +1,8 @@
 # Install
 
 `claude-session` installs as a multi-file layout: a shim in `bin/` plus
-a `lib/` tree, a completions script, and a man page. The `justfile`
-orchestrates install, uninstall, test, lint, and man-page build.
+a `lib/` tree and a completions script. The `justfile` orchestrates
+install, uninstall, test, and lint.
 
 ## Install matrix
 
@@ -15,7 +15,6 @@ XDG-aware, `PREFIX`-overridable. The **user** column is the default
 | binary            | `$HOME/.local/bin/claude-session`                      | `$PREFIX/bin/claude-session`                              |
 | lib tree          | `$HOME/.local/lib/claude-session/`                     | `$PREFIX/lib/claude-session/`                             |
 | bash completion   | `$XDG_DATA_HOME/bash-completion/completions/`          | `$(pkg-config --variable=completionsdir bash-completion)` |
-| man page          | `$XDG_DATA_HOME/man/man1/claude-session.1`             | `$PREFIX/share/man/man1/claude-session.1`                 |
 | config            | `$XDG_CONFIG_HOME/claude-session/config.env`           | `/etc/claude-session/config.env`                          |
 | state             | `${XDG_STATE_HOME:-$HOME/.local/state}/claude-session/` | `/var/lib/claude-session/`                                |
 
@@ -38,7 +37,6 @@ XDG-aware, `PREFIX`-overridable. The **user** column is the default
 - `flock` — exit-time sync safety under concurrent terminals.
 - `just` — recipe orchestration. Optional for install (`install.sh`
   works standalone), required for the test/lint workflow.
-- `scdoc` — only needed when building the man page (`just man`).
 
 ## Recipes
 
@@ -56,9 +54,8 @@ build/test/lint/install operations. Its recipes:
 | `just test-integration`                 | `bats --filter-tags integration test/`.                                                                                   |
 | `just lint`                             | `pre-commit run --all-files`. Never invoke shellcheck/shfmt directly — always through pre-commit.                         |
 | `just check`                            | `just lint && just test`. The gate CI runs.                                                                                |
-| `just man`                              | `scdoc < man/claude-session.1.scd > man/claude-session.1`.                                                                 |
 | `just completions`                      | Copy `completions/claude-session.bash` to the target completions dir (honors user vs system install).                      |
-| `just clean`                            | Remove generated artifacts (`man/*.1` built output, bats tempdirs). Does **not** touch anything installed outside the repo. |
+| `just clean`                            | Remove generated artifacts (bats tempdirs). Does **not** touch anything installed outside the repo.                        |
 
 Style conventions:
 
@@ -77,7 +74,6 @@ Available recipes:
     completions             # install bash completions
     install PREFIX=""       # install claude-session (user scope if PREFIX empty)
     lint                    # run pre-commit on all files
-    man                     # build man page via scdoc
     test                    # run unit + integration tests
     test-integration        # run integration bats tests
     test-unit               # run unit bats tests

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s inherit_errexit 2>/dev/null || true
+
+completions_only=0
+if [[ "${1:-}" == "--completions-only" ]]; then
+  completions_only=1
+fi
+
+repo_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+user_mode=0
+if [[ $EUID -ne 0 && -z "${PREFIX:-}" ]]; then
+  user_mode=1
+fi
+
+if [[ $user_mode -eq 1 ]]; then
+  bin_dir="$HOME/.local/bin"
+  lib_dir="$HOME/.local/lib/claude-session"
+  data_dir="${XDG_DATA_HOME:-$HOME/.local/share}"
+  completion_dir="$data_dir/bash-completion/completions"
+  state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/claude-session"
+else
+  prefix=${PREFIX:-/usr/local}
+  bin_dir="$prefix/bin"
+  lib_dir="$prefix/lib/claude-session"
+  if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists bash-completion 2>/dev/null; then
+    completion_dir=$(pkg-config --variable=completionsdir bash-completion)
+  else
+    completion_dir="$prefix/share/bash-completion/completions"
+  fi
+  state_dir="/var/lib/claude-session"
+fi
+
+manifest="$state_dir/install-manifest"
+new_manifest="$manifest.tmp.$$"
+mkdir -p "$state_dir"
+: >"$new_manifest"
+
+record() {
+  printf '%s\n' "$1" >>"$new_manifest"
+}
+
+install_one() {
+  local src=$1
+  local dst=$2
+  local mode=${3:-644}
+  mkdir -p "$(dirname "$dst")"
+  cp "$src" "$dst"
+  chmod "$mode" "$dst"
+  record "$dst"
+}
+
+if [[ $completions_only -eq 0 ]]; then
+  mkdir -p "$lib_dir" "$lib_dir/commands" "$lib_dir/functions"
+  # Record directories first; uninstall iterates the manifest in reverse,
+  # so files come off first, then their subdirectories, then the parent.
+  record "$lib_dir"
+  record "$lib_dir/commands"
+  record "$lib_dir/functions"
+  install_one "$repo_dir/bin/claude-session" "$bin_dir/claude-session" 755
+  for src in "$repo_dir/lib"/*.sh; do
+    install_one "$src" "$lib_dir/$(basename "$src")" 644
+  done
+  for src in "$repo_dir/lib/commands"/*.sh; do
+    install_one "$src" "$lib_dir/commands/$(basename "$src")" 644
+  done
+  for src in "$repo_dir/lib/functions"/*.sh; do
+    install_one "$src" "$lib_dir/functions/$(basename "$src")" 644
+  done
+fi
+
+install_one "$repo_dir/completions/claude-session.bash" "$completion_dir/claude-session.bash" 644
+
+if [[ $completions_only -eq 1 && -f "$manifest" ]]; then
+  # Merge: preserve every previously installed path that is not the
+  # completions file we just rewrote, then append the fresh manifest line.
+  while IFS= read -r old; do
+    [[ -n "$old" ]] || continue
+    [[ "$old" == "$completion_dir/claude-session.bash" ]] && continue
+    grep -Fxq "$old" "$new_manifest" || printf '%s\n' "$old" >>"$new_manifest"
+  done <"$manifest"
+elif [[ -f "$manifest" ]]; then
+  # Full install: any path in the previous manifest absent from the new one
+  # is stale and should be removed.
+  while IFS= read -r old; do
+    [[ -n "$old" ]] || continue
+    if ! grep -Fxq "$old" "$new_manifest"; then
+      if [[ -f "$old" || -L "$old" ]]; then
+        rm -f "$old"
+      elif [[ -d "$old" ]]; then
+        rmdir "$old" 2>/dev/null || true
+      fi
+    fi
+  done <"$manifest"
+fi
+mv -f "$new_manifest" "$manifest"
+
+if [[ $user_mode -eq 1 && ":$PATH:" != *":$HOME/.local/bin:"* ]]; then
+  # shellcheck disable=SC2016  # literal $HOME and $PATH for the user to copy/paste
+  printf '[claude-session] warning: add this to your shell rc: export PATH="$HOME/.local/bin:$PATH"\n' >&2
+fi

--- a/justfile
+++ b/justfile
@@ -1,0 +1,40 @@
+# list available recipes
+default:
+  @just --list
+
+# install claude-session
+install PREFIX="":
+  PREFIX="{{PREFIX}}" ./install.sh
+
+# remove files listed in the install manifest
+uninstall PREFIX="":
+  PREFIX="{{PREFIX}}" ./uninstall.sh
+
+# run unit + integration tests
+test: test-unit test-integration
+
+# run unit bats tests
+test-unit:
+  @if ! command -v bats >/dev/null 2>&1; then printf '%s\n' "bats not found; install bats-core" >&2; exit 127; fi
+  bats --filter-tags 'unit,!integration' test/
+
+# run integration bats tests
+test-integration:
+  @if ! command -v bats >/dev/null 2>&1; then printf '%s\n' "bats not found; install bats-core" >&2; exit 127; fi
+  bats --filter-tags integration test/
+
+# run pre-commit on all files
+lint:
+  pre-commit run --all-files
+
+# run lint + test (CI gate)
+check:
+  just lint && just test
+
+# install bash completions
+completions PREFIX="":
+  PREFIX="{{PREFIX}}" ./install.sh --completions-only
+
+# remove generated artifacts (non-destructive)
+clean:
+  find test -type d -name 'bats-run-*' -prune -exec rm -rf {} +

--- a/lib/commands/cmd_config.sh
+++ b/lib/commands/cmd_config.sh
@@ -1,0 +1,86 @@
+# shellcheck shell=bash
+: 'desc: Inspect, locate, or edit claude-session configuration.'
+
+__config_help() {
+  cat <<'EOF'
+USAGE:
+  claude-session config show [--verbose]
+  claude-session config path
+  claude-session config edit
+EOF
+}
+
+__config_show() {
+  local verbose=${1:-0}
+  local keys=(
+    CLAUDE_SESSION_CONFIG_DIR
+    CLAUDE_SESSION_SHARED_DIR
+    CLAUDE_SESSION_PROFILE
+    CLAUDE_SESSION_REAL_CLAUDE
+    CLAUDE_SESSION_OAUTH_CMD
+    CLAUDE_SESSION_POST_EXIT_CMD
+    CLAUDE_SESSION_SYNC_FILES
+    CLAUDE_SESSION_LINK_FILES
+    CLAUDE_SESSION_LINK_DIRS
+    CLAUDE_SESSION_VERBOSE
+  )
+  local key=""
+  local value=""
+  for key in "${keys[@]}"; do
+    case "$key" in
+      CLAUDE_SESSION_CONFIG_DIR) value=${CLAUDE_SESSION_CONFIG_DIR:-$(cs::helpers::config_dir_default)} ;;
+      CLAUDE_SESSION_SHARED_DIR) value=${CLAUDE_SESSION_SHARED_DIR:-$HOME/.claude} ;;
+      CLAUDE_SESSION_PROFILE) value=${CLAUDE_SESSION_PROFILE:-default} ;;
+      CLAUDE_SESSION_REAL_CLAUDE) value=${CLAUDE_SESSION_REAL_CLAUDE:-"(unset, auto-discover)"} ;;
+      CLAUDE_SESSION_SYNC_FILES) value=${CLAUDE_SESSION_SYNC_FILES:-.credentials.json} ;;
+      CLAUDE_SESSION_LINK_FILES) value=${CLAUDE_SESSION_LINK_FILES:-settings.local.json:keybindings.json:CLAUDE.md} ;;
+      CLAUDE_SESSION_LINK_DIRS) value=${CLAUDE_SESSION_LINK_DIRS:-skills:agents:rules:commands:hooks} ;;
+      CLAUDE_SESSION_VERBOSE) value=${CLAUDE_SESSION_VERBOSE:-0} ;;
+      *) value=${!key:-"(unset)"} ;;
+    esac
+    value=$(cs::helpers::redact "$key" "$value" "$verbose")
+    printf '%s=%s\n' "$key" "$value"
+  done
+}
+
+__config_path() {
+  cs::helpers::config_path
+}
+
+__config_edit() {
+  local file
+  file=$(cs::helpers::config_path)
+  local dir
+  dir=$(dirname "$file")
+  mkdir -p "$dir" || cs::helpers::die 3 "could not create config directory." "Failed to create $dir." "  Check parent directory permissions."
+  chmod 700 "$dir" || true
+  if [[ ! -e "$file" ]]; then
+    : >"$file" || cs::helpers::die 3 "could not create config file." "Failed to create $file." "  Check directory permissions."
+    chmod 600 "$file" || true
+  fi
+  "${EDITOR:-${VISUAL:-vi}}" "$file"
+}
+
+cs::cmd::config() {
+  local sub=${1:-}
+  [[ $# -gt 0 ]] && shift
+  local verbose=0
+  local arg=""
+  for arg in "$@"; do
+    case "$arg" in
+      --verbose) verbose=1 ;;
+      --help | -h)
+        __config_help
+        return 0
+        ;;
+      *) cs::helpers::die 2 "unknown config flag \"$arg\"." "The config command did not understand \"$arg\"." "  claude-session config --help" ;;
+    esac
+  done
+  case "$sub" in
+    show) __config_show "$verbose" ;;
+    path) __config_path ;;
+    edit) __config_edit ;;
+    --help | -h | "") __config_help ;;
+    *) cs::helpers::die 2 "unknown config subcommand \"$sub\"." "Expected show, path, or edit." "  claude-session config --help" ;;
+  esac
+}

--- a/lib/commands/cmd_doctor.sh
+++ b/lib/commands/cmd_doctor.sh
@@ -1,0 +1,187 @@
+# shellcheck shell=bash
+: 'desc: Run structured health checks for claude-session.'
+
+__doctor_help() {
+  cat <<'EOF'
+USAGE:
+  claude-session doctor [--verbose]
+EOF
+}
+
+__doctor_line() {
+  printf '%-14s %-5s %s\n' "$1" "$2" "$3"
+}
+
+cs::cmd::doctor() {
+  local verbose=${CLAUDE_SESSION_VERBOSE:-0}
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --verbose) verbose=1 ;;
+      --help | -h)
+        __doctor_help
+        return 0
+        ;;
+      *) cs::helpers::die 2 "unknown doctor flag \"$1\"." "The doctor command did not understand \"$1\"." "  claude-session doctor --help" ;;
+    esac
+    shift
+  done
+
+  local fails=0
+  local next=""
+  local config_file
+  config_file=$(cs::helpers::config_path)
+  if [[ -f "$config_file" ]]; then
+    local mode
+    mode=$(stat -c '%a' "$config_file" 2>/dev/null || printf '000')
+    if ((8#$mode > 600)); then
+      __doctor_line "config" "WARN" "$config_file (mode $mode; consider chmod 600)"
+      next="${next}  chmod 600 \"$config_file\""$'\n'
+    else
+      __doctor_line "config" "OK" "$config_file (mode $mode)"
+    fi
+  else
+    __doctor_line "config" "WARN" "no config file found at $config_file"
+  fi
+
+  local shared_dir=${CLAUDE_SESSION_SHARED_DIR:-$HOME/.claude}
+  if [[ -d "$shared_dir" && -r "$shared_dir" ]]; then
+    __doctor_line "shared dir" "OK" "$shared_dir (exists, readable)"
+  else
+    __doctor_line "shared dir" "FAIL" "$shared_dir missing or unreadable"
+    fails=$((fails + 1))
+    next="${next}  mkdir -p \"$shared_dir\""$'\n'
+  fi
+
+  cs::helpers::source_fn resolve_profile
+  # Run the resolver in a subshell so its die/exit cannot abort doctor.
+  local profile_err
+  profile_err=$(mktemp)
+  if (cs::fn::resolve_profile) 2>"$profile_err"; then
+    __doctor_line "profile" "OK" "\"${CLAUDE_SESSION_PROFILE:-default}\""
+    # Re-run in the current shell now that we know it succeeds, so the
+    # rest of doctor sees the resolved profile env.
+    cs::fn::resolve_profile
+  else
+    local prof=${CS_CLI_PROFILE:-${CLAUDE_SESSION_PROFILE:-default}}
+    __doctor_line "profile" "FAIL" "profile \"$prof\" could not be resolved"
+    fails=$((fails + 1))
+    next="${next}  Run:  claude-session profile list"$'\n'
+  fi
+  rm -f "$profile_err"
+
+  cs::helpers::source_fn real_claude
+  local real=""
+  local err
+  err=$(mktemp)
+  if real=$(cs::fn::real_claude 2>"$err"); then
+    __doctor_line "real claude" "OK" "$real"
+  else
+    __doctor_line "real claude" "FAIL" "$(tr '\n' ' ' <"$err")"
+    fails=$((fails + 1))
+    next="${next}  Set CLAUDE_SESSION_REAL_CLAUDE=/path/to/claude"$'\n'
+  fi
+  rm -f "$err"
+
+  if [[ -n "${CLAUDE_SESSION_OAUTH_CMD:-}" ]]; then
+    if command -v timeout >/dev/null 2>&1; then
+      __doctor_line "oauth hook" "OK" "configured"
+    else
+      __doctor_line "oauth hook" "WARN" "configured, but timeout not found"
+    fi
+  else
+    __doctor_line "oauth hook" "—" "CLAUDE_SESSION_OAUTH_CMD unset (skipped)"
+  fi
+  if [[ -n "${CLAUDE_SESSION_POST_EXIT_CMD:-}" ]]; then
+    __doctor_line "post-exit hook" "OK" "configured"
+  else
+    __doctor_line "post-exit hook" "—" "CLAUDE_SESSION_POST_EXIT_CMD unset (skipped)"
+  fi
+
+  cs::helpers::source_fn session_dir
+  local root=""
+  err=$(mktemp)
+  if root=$(cs::fn::session_dir 2>"$err"); then
+    local root_source
+    root_source=$(cs::fn::session_root_source_for "$root")
+    if [[ "$root_source" == "runtime" ]]; then
+      __doctor_line "session root" "OK" "$root/  (XDG_RUNTIME_DIR, mode 700)"
+    else
+      __doctor_line "session root" "WARN" "$root/  (XDG_STATE_HOME fallback)"
+      next="${next}  Restore or set XDG_RUNTIME_DIR"$'\n'
+    fi
+  else
+    __doctor_line "session root" "FAIL" "$(tr '\n' ' ' <"$err")"
+    fails=$((fails + 1))
+  fi
+  rm -f "$err"
+
+  if command -v jq >/dev/null 2>&1; then
+    __doctor_line "jq" "OK" "$(command -v jq)"
+  else
+    __doctor_line "jq" "FAIL" "jq not found"
+    fails=$((fails + 1))
+  fi
+  if command -v flock >/dev/null 2>&1; then
+    __doctor_line "flock" "OK" "$(command -v flock)"
+  else
+    __doctor_line "flock" "FAIL" "flock not found"
+    fails=$((fails + 1))
+  fi
+  if command -v timeout >/dev/null 2>&1; then
+    __doctor_line "timeout" "OK" "$(command -v timeout)"
+  else
+    __doctor_line "timeout" "WARN" "timeout not found; OAuth hook timeout disabled"
+  fi
+
+  printf '\nSessions\n'
+  cs::helpers::source_fn session_inventory
+  cs::fn::session_inventory || true
+
+  if [[ $verbose -eq 1 ]]; then
+    printf '\nEnvironment\n'
+    printf 'CLAUDE_SESSION_PROFILE=%s\n' "${CLAUDE_SESSION_PROFILE:-default}"
+    printf 'CLAUDE_SESSION_CONFIG_DIR=%s\n' "$(cs::helpers::config_dir_default)"
+    printf 'CLAUDE_SESSION_SHARED_DIR=%s\n' "$shared_dir"
+    # Per docs/commands.md: also surface the env vars the active profile
+    # would set (CLAUDE_CODE_*, ANTHROPIC_*, etc), with redaction unless
+    # --verbose was *also* passed (which it is, here, so values are shown
+    # except for *_TOKEN / *_SECRET / *_KEY / *_PASSWORD / OAUTH_CMD per
+    # the secret-key rule).
+    local config_dir
+    config_dir=$(cs::helpers::config_dir_default)
+    local profile=${CLAUDE_SESSION_PROFILE:-default}
+    local profile_file="$config_dir/profiles/$profile.env"
+    if [[ -f "$profile_file" ]]; then
+      printf '# profile vars from %s\n' "$profile_file"
+      local kv key value
+      # shellcheck disable=SC2016  # script body for inner bash -c; vars expand in child
+      while IFS= read -r kv; do
+        [[ -n "$kv" ]] || continue
+        [[ "$kv" == *=* ]] || continue
+        key=${kv%%=*}
+        value=${kv#*=}
+        case "$key" in
+          HOME | PATH | PWD | SHLVL | _ | OLDPWD | CS_PROFILE_FILE | CS_LIB_DIR) continue ;;
+        esac
+        # In verbose mode we still apply the suffix-based secret redaction
+        # to keep tokens out of triage paste-bins.
+        value=$(cs::helpers::redact "$key" "$value" 0)
+        printf '%s=%s\n' "$key" "$value"
+      done < <(env -i HOME="$HOME" PATH="$PATH" \
+        CS_PROFILE_FILE="$profile_file" CS_LIB_DIR="${LIB_DIR:-}" \
+        bash -c '
+          # shellcheck source=/dev/null
+          . "$CS_LIB_DIR/helpers.sh"
+          # shellcheck source=/dev/null
+          . "$CS_LIB_DIR/functions/fn_load_config.sh"
+          cs::fn::__apply_dotenv "$CS_PROFILE_FILE"
+          env -0 | tr "\0" "\n"
+        ' 2>/dev/null) || true
+    fi
+  fi
+
+  if [[ -n "$next" ]]; then
+    printf '\nNext:\n%s' "$next"
+  fi
+  [[ $fails -eq 0 ]]
+}

--- a/lib/commands/cmd_profile.sh
+++ b/lib/commands/cmd_profile.sh
@@ -1,0 +1,108 @@
+# shellcheck shell=bash
+: 'desc: List profiles or show one profile dotenv file.'
+
+__profile_help() {
+  cat <<'EOF'
+USAGE:
+  claude-session profile list
+  claude-session profile show <name> [--verbose]
+EOF
+}
+
+__profile_list() {
+  local config_dir
+  config_dir=$(cs::helpers::config_dir_default)
+  local dir="$config_dir/profiles"
+  [[ -e "$dir" ]] || return 0
+  [[ -r "$dir" ]] || cs::helpers::die 3 "profiles directory unreadable." "Cannot read $dir." "  chmod u+r \"$dir\""
+  local active=${CLAUDE_SESSION_PROFILE:-default}
+  local file=""
+  while IFS= read -r file; do
+    [[ -n "$file" ]] || continue
+    local name
+    name=$(basename "$file" .env)
+    if [[ "$name" == "$active" ]]; then
+      printf '* %s\n' "$name"
+    else
+      printf '  %s\n' "$name"
+    fi
+  done < <(find "$dir" -maxdepth 1 -type f -name '*.env' -print | sort)
+}
+
+__profile_show() {
+  local name=$1
+  local verbose=$2
+  local config_dir
+  config_dir=$(cs::helpers::config_dir_default)
+  local file="$config_dir/profiles/$name.env"
+  local overlay="$config_dir/profiles/$name.settings.json"
+  [[ -f "$file" ]] || cs::helpers::die 6 "profile \"$name\" not found." "No file at $file." "  List available profiles:  claude-session profile list" "claude-session profile list"
+  cs::helpers::source_fn load_config
+  cs::fn::validate_dotenv "$file"
+  printf '# profile: %s\n' "$name"
+  printf '# source: %s\n' "$file"
+  # Apply the validated dotenv in an isolated subshell so the parent
+  # environment is not polluted, then dump only the keys the profile
+  # actually defined. We use the same line-parser the loader uses so
+  # values like `pass show <secret>` are not executed as commands.
+  local profile_keys
+  # shellcheck disable=SC2016  # script body for inner bash -c; vars expand in child
+  if ! profile_keys=$(env -i HOME="$HOME" PATH="$PATH" \
+      CS_PROFILE_FILE="$file" CS_LIB_DIR="${LIB_DIR:-}" \
+      bash -c '
+        # shellcheck source=/dev/null
+        . "$CS_LIB_DIR/helpers.sh"
+        # shellcheck source=/dev/null
+        . "$CS_LIB_DIR/functions/fn_load_config.sh"
+        cs::fn::__apply_dotenv "$CS_PROFILE_FILE"
+        env -0 | tr "\0" "\n"
+      ' 2>/dev/null); then
+    cs::helpers::die 3 "profile \"$name\" failed to load." "Sourcing $file produced an error." "  Edit the file and re-run claude-session profile show $name."
+  fi
+  local kv key value
+  while IFS= read -r kv; do
+    [[ -n "$kv" ]] || continue
+    [[ "$kv" == *=* ]] || continue
+    key=${kv%%=*}
+    value=${kv#*=}
+    case "$key" in
+      HOME | PATH | PWD | SHLVL | _ | OLDPWD | CS_PROFILE_FILE | CS_LIB_DIR) continue ;;
+    esac
+    value=$(cs::helpers::redact "$key" "$value" "$verbose")
+    printf '%s=%s\n' "$key" "$value"
+  done <<<"$profile_keys"
+  if [[ -f "$overlay" ]]; then
+    printf '# overlay: %s\n' "$overlay"
+  fi
+}
+
+cs::cmd::profile() {
+  local sub=${1:-}
+  [[ $# -gt 0 ]] && shift
+  case "$sub" in
+    list)
+      [[ $# -eq 0 ]] || cs::helpers::die 2 "profile list takes no arguments." "Unexpected argument: $1" "  claude-session profile list"
+      __profile_list
+      ;;
+    show)
+      local name=${1:-}
+      [[ -n "$name" ]] || cs::helpers::die 2 "missing profile name." "profile show requires a profile name." "  claude-session profile show default"
+      shift
+      local verbose=0
+      while [[ $# -gt 0 ]]; do
+        case "$1" in
+          --verbose) verbose=1 ;;
+          --help | -h)
+            __profile_help
+            return 0
+            ;;
+          *) cs::helpers::die 2 "unknown profile flag \"$1\"." "The profile command did not understand \"$1\"." "  claude-session profile --help" ;;
+        esac
+        shift
+      done
+      __profile_show "$name" "$verbose"
+      ;;
+    --help | -h | "") __profile_help ;;
+    *) cs::helpers::die 2 "unknown profile subcommand \"$sub\"." "Expected list or show." "  claude-session profile --help" ;;
+  esac
+}

--- a/lib/commands/cmd_run.sh
+++ b/lib/commands/cmd_run.sh
@@ -1,0 +1,176 @@
+# shellcheck shell=bash
+: 'desc: Wrap the real claude binary with per-terminal session isolation.'
+
+__run_help() {
+  cat <<'EOF'
+USAGE:
+  claude-session run [--profile <name>] [--dry-run] [-- <claude_args>...]
+  claude-session [<claude_args>...]
+EOF
+}
+
+__run_write_meta() {
+  local file=$1
+  local profile=$2
+  local terminal_id=$3
+  local root=$4
+  local source=$5
+  local cwd=$6
+  local started_at
+  started_at=$(date -u '+%FT%TZ')
+  local tmp="$file.tmp.$$"
+  {
+    printf '{\n'
+    printf '  "schema": 1,\n'
+    printf '  "profile": "%s",\n' "$(cs::helpers::json_escape "$profile")"
+    printf '  "terminal_id": "%s",\n' "$(cs::helpers::json_escape "$terminal_id")"
+    printf '  "started_at": "%s",\n' "$started_at"
+    printf '  "cwd": "%s",\n' "$(cs::helpers::json_escape "$cwd")"
+    printf '  "session_root": "%s",\n' "$(cs::helpers::json_escape "$root")"
+    printf '  "session_root_source": "%s"\n' "$(cs::helpers::json_escape "$source")"
+    printf '}\n'
+  } >"$tmp"
+  mv -f "$tmp" "$file"
+}
+
+__cs_run_exit_trap() {
+  local fallback=$?
+  local status
+  if [[ -n "${__CS_RUN_FORCED_STATUS:-}" ]]; then
+    status=$__CS_RUN_FORCED_STATUS
+  elif [[ -n "${__CS_RUN_CHILD_STATUS_SET:-}" ]]; then
+    status=$__CS_RUN_CHILD_STATUS
+  else
+    status=$fallback
+  fi
+  trap - EXIT
+  if [[ -n "${__CS_RUN_SESSION_DIR:-}" && -n "${__CS_RUN_SHARED_DIR:-}" ]]; then
+    cs::helpers::source_fn sync_files
+    cs::fn::sync_files out "$__CS_RUN_SESSION_DIR" "$__CS_RUN_SHARED_DIR" || true
+  fi
+  if [[ -n "${CLAUDE_SESSION_POST_EXIT_CMD:-}" ]]; then
+    cs::helpers::source_fn run_hook
+    CLAUDE_SESSION_DIR=${__CS_RUN_SESSION_DIR:-}
+    export CLAUDE_SESSION_DIR CLAUDE_SESSION_PROFILE
+    cs::fn::run_hook "$CLAUDE_SESSION_POST_EXIT_CMD" >/dev/null || true
+  fi
+  exit "$status"
+}
+
+cs::cmd::run() {
+  local dry_run=${CLAUDE_SESSION_DRY_RUN:-0}
+  local -a pass_args=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --profile)
+        [[ -n "${2:-}" ]] || cs::helpers::die 2 "missing value for --profile." "--profile requires a profile name." "  claude-session run --profile default"
+        CS_CLI_PROFILE=$2
+        CLAUDE_SESSION_PROFILE=$2
+        export CS_CLI_PROFILE CLAUDE_SESSION_PROFILE
+        cs::helpers::source_fn resolve_profile
+        cs::fn::resolve_profile
+        shift 2
+        ;;
+      --dry-run)
+        dry_run=1
+        shift
+        ;;
+      --help | -h)
+        __run_help
+        return 0
+        ;;
+      --)
+        shift
+        pass_args=("$@")
+        break
+        ;;
+      *)
+        pass_args+=("$1")
+        shift
+        ;;
+    esac
+  done
+
+  local bare=0
+  local arg=""
+  for arg in "${pass_args[@]}"; do
+    [[ "$arg" == "--bare" ]] && bare=1
+  done
+
+  local shared_dir=${CLAUDE_SESSION_SHARED_DIR:-$HOME/.claude}
+  mkdir -p "$shared_dir"
+
+  cs::helpers::source_fn terminal_id
+  cs::helpers::source_fn session_dir
+  cs::helpers::source_fn sync_files
+  cs::helpers::source_fn link_files
+  cs::helpers::source_fn merge_settings
+  cs::helpers::source_fn real_claude
+  cs::helpers::source_fn run_hook
+
+  local root
+  root=$(cs::fn::session_dir)
+  local root_source
+  root_source=$(cs::fn::session_root_source_for "$root")
+  local terminal_id
+  terminal_id=$(cs::fn::terminal_id)
+  local session_dir="$root/sessions/$terminal_id"
+  mkdir -p "$session_dir"
+  chmod 700 "$session_dir"
+
+  cs::fn::sync_files in "$session_dir" "$shared_dir"
+  cs::fn::link_files "$session_dir" "$shared_dir"
+  cs::fn::merge_settings "$shared_dir" "${CLAUDE_SESSION_PROFILE:-default}" "$session_dir" "${CLAUDE_SESSION_CONFIG_DIR:-$(cs::helpers::config_dir_default)}"
+  __run_write_meta "$session_dir/session-meta.json" "${CLAUDE_SESSION_PROFILE:-default}" "$terminal_id" "$root" "$root_source" "$PWD"
+
+  local real_claude
+  real_claude=$(cs::fn::real_claude)
+
+  if [[ $bare -eq 0 && -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" && -n "${CLAUDE_SESSION_OAUTH_CMD:-}" ]]; then
+    local token=""
+    if token=$(cs::fn::run_hook "$CLAUDE_SESSION_OAUTH_CMD" --timeout 5 --fatal); then
+      token=${token//$'\n'/}
+      token=${token//$'\r'/}
+      if [[ -n "${token//[[:space:]]/}" ]]; then
+        CLAUDE_CODE_OAUTH_TOKEN=$token
+        export CLAUDE_CODE_OAUTH_TOKEN
+      fi
+    fi
+    if [[ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ]]; then
+      cs::helpers::die 7 "OAuth hook failed." "CLAUDE_SESSION_OAUTH_CMD did not provide a token and CLAUDE_CODE_OAUTH_TOKEN is unset." "  Fix CLAUDE_SESSION_OAUTH_CMD or export CLAUDE_CODE_OAUTH_TOKEN." "claude-session doctor"
+    fi
+  fi
+
+  export CLAUDE_CONFIG_DIR=$session_dir
+  export CLAUDE_SESSION_DIR=$session_dir
+  export CLAUDE_SESSION_PROFILE=${CLAUDE_SESSION_PROFILE:-default}
+
+  if [[ $dry_run -eq 1 ]]; then
+    printf 'session_dir=%s\n' "$session_dir"
+    printf 'settings=%s\n' "$session_dir/settings.json"
+    printf 'oauth_hook=%s\n' "$([[ $bare -eq 1 ]] && printf 'skipped (--bare)' || printf '%s' "${CLAUDE_SESSION_OAUTH_CMD:-unset}")"
+    printf 'post_exit_hook=%s\n' "${CLAUDE_SESSION_POST_EXIT_CMD:-unset}"
+    printf 'real_claude=%s\n' "$real_claude"
+    printf 'argv=%s' "$real_claude"
+    for arg in "${pass_args[@]}"; do
+      printf ' %q' "$arg"
+    done
+    printf '\n'
+    return 0
+  fi
+
+  __CS_RUN_SESSION_DIR=$session_dir
+  __CS_RUN_SHARED_DIR=$shared_dir
+  __CS_RUN_CHILD_STATUS=0
+  __CS_RUN_CHILD_STATUS_SET=""
+  __CS_RUN_FORCED_STATUS=""
+  export __CS_RUN_SESSION_DIR __CS_RUN_SHARED_DIR __CS_RUN_CHILD_STATUS \
+    __CS_RUN_CHILD_STATUS_SET __CS_RUN_FORCED_STATUS
+  trap '__cs_run_exit_trap' EXIT
+  trap '__CS_RUN_FORCED_STATUS=130; exit 130' INT
+  trap '__CS_RUN_FORCED_STATUS=143; exit 143' TERM
+
+  "$real_claude" "${pass_args[@]}" && __CS_RUN_CHILD_STATUS=0 || __CS_RUN_CHILD_STATUS=$?
+  __CS_RUN_CHILD_STATUS_SET=1
+  return "$__CS_RUN_CHILD_STATUS"
+}

--- a/lib/commands/cmd_session.sh
+++ b/lib/commands/cmd_session.sh
@@ -1,0 +1,144 @@
+# shellcheck shell=bash
+: 'desc: List and clean claude-session session directories.'
+
+__session_help() {
+  cat <<'EOF'
+USAGE:
+  claude-session session list [--absolute] [--no-header]
+  claude-session session clean [--older-than <duration>] [--dry-run] [--yes]
+EOF
+}
+
+__parse_duration() {
+  local dur=$1
+  [[ "$dur" =~ ^([0-9]+)([smhdw])$ ]] || return 1
+  local n=${BASH_REMATCH[1]}
+  local u=${BASH_REMATCH[2]}
+  case "$u" in
+    s) printf '%s\n' "$n" ;;
+    m) printf '%s\n' "$((n * 60))" ;;
+    h) printf '%s\n' "$((n * 3600))" ;;
+    d) printf '%s\n' "$((n * 86400))" ;;
+    w) printf '%s\n' "$((n * 604800))" ;;
+  esac
+}
+
+__session_list() {
+  cs::helpers::source_fn session_inventory
+  cs::fn::session_inventory "$@"
+}
+
+__session_clean() {
+  local older_than=""
+  local dry_run=${CLAUDE_SESSION_DRY_RUN:-0}
+  local yes=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --older-than)
+        older_than=${2:-}
+        [[ -n "$older_than" ]] || cs::helpers::die 2 "missing duration." "--older-than requires a duration like 7d." "  claude-session session clean --older-than 7d --dry-run"
+        shift 2
+        ;;
+      --dry-run)
+        dry_run=1
+        shift
+        ;;
+      --yes)
+        yes=1
+        shift
+        ;;
+      --help | -h)
+        __session_help
+        return 0
+        ;;
+      *) cs::helpers::die 2 "unknown session clean flag \"$1\"." "The session clean command did not understand \"$1\"." "  claude-session session clean --help" ;;
+    esac
+  done
+
+  local age_seconds=""
+  if [[ -n "$older_than" ]]; then
+    age_seconds=$(__parse_duration "$older_than") || cs::helpers::die 2 "invalid duration \"$older_than\"." "Use N[smhdw], for example 30s, 15m, 2h, 7d, 4w." "  claude-session session clean --older-than 7d --dry-run"
+  fi
+
+  cs::helpers::source_fn session_dir
+  local root
+  root=$(cs::fn::session_dir)
+  local parent="$root/sessions"
+  local now
+  now=$(date +%s)
+  local -a candidates=()
+  local dir=""
+  shopt -u failglob
+  shopt -s nullglob
+  for dir in "$parent"/*; do
+    [[ -d "$dir" ]] || continue
+    local id
+    id=$(basename "$dir")
+    local status
+    cs::helpers::source_fn session_inventory
+    status=$(__session_status "$id")
+    [[ "$status" == "stale" ]] || continue
+    if [[ -n "$age_seconds" ]]; then
+      local mtime
+      mtime=$(stat -c '%Y' "$dir")
+      [[ $((now - mtime)) -gt $age_seconds ]] || continue
+    fi
+    candidates+=("$dir")
+  done
+
+  printf 'Would remove %s stale session directories under\n%s:\n' "${#candidates[@]}" "$parent"
+  local cand_id cand_date cand_size
+  for dir in "${candidates[@]}"; do
+    cand_id=$(basename "$dir")
+    cand_date=$(date -u -r "$dir" '+%Y-%m-%d' 2>/dev/null || printf 'unknown')
+    cand_size=$(du -sh "$dir" 2>/dev/null | awk '{print $1}')
+    [[ -n "$cand_size" ]] || cand_size="?"
+    printf '  %-12s (%s, %s)\n' "$cand_id" "$cand_date" "$cand_size"
+  done
+  if [[ $dry_run -eq 1 || ${#candidates[@]} -eq 0 ]]; then
+    printf '\nNext:\n  Remove them:  claude-session session clean --yes\n'
+    return 0
+  fi
+  if [[ $yes -ne 1 && ! -t 0 ]]; then
+    cs::helpers::die 2 "confirmation required." "stdin is not a TTY, so session clean requires --yes." "  claude-session session clean --yes"
+  fi
+  if [[ $yes -ne 1 ]]; then
+    printf 'Remove these directories? [y/N] ' >&2
+    local answer=""
+    read -r answer
+    [[ "$answer" == "y" || "$answer" == "Y" ]] || return 0
+  fi
+  local failures=0
+  local -a failed=()
+  for dir in "${candidates[@]}"; do
+    if ! rm -rf -- "$dir" 2>/dev/null; then
+      failures=$((failures + 1))
+      failed+=("$dir")
+    fi
+  done
+  if [[ $failures -ne 0 ]]; then
+    cs::helpers::source_fn error
+    local list=""
+    local f
+    for f in "${failed[@]}"; do
+      list+="    $f"$'\n'
+    done
+    cs::fn::error \
+      "session clean removed $((${#candidates[@]} - failures))/${#candidates[@]} directories." \
+      "$failures session director$( [[ $failures -eq 1 ]] && printf y || printf ies) could not be removed:"$'\n'"${list%$'\n'}" \
+      "  Check permissions and re-run:  claude-session session clean --yes" \
+      "claude-session doctor"
+    return 1
+  fi
+}
+
+cs::cmd::session() {
+  local sub=${1:-}
+  [[ $# -gt 0 ]] && shift
+  case "$sub" in
+    list) __session_list "$@" ;;
+    clean) __session_clean "$@" ;;
+    --help | -h | "") __session_help ;;
+    *) cs::helpers::die 2 "unknown session subcommand \"$sub\"." "Expected list or clean." "  claude-session session --help" ;;
+  esac
+}

--- a/lib/commands/cmd_usage.sh
+++ b/lib/commands/cmd_usage.sh
@@ -1,0 +1,75 @@
+# shellcheck shell=bash
+: 'desc: Print the full stable claude-session command reference.'
+
+cs::cmd::usage() {
+  cat <<EOF
+claude-session 0.1.0
+
+USAGE:
+  claude-session [--profile <name>] [--config <path>] [--verbose] [--dry-run] <command> [args...]
+  claude-session [<claude_args>...]
+
+COMMAND TREE:
+  run [--profile <name>] [--dry-run] [-- <claude_args>...]
+  doctor [--verbose]
+  usage
+  config show|path|edit
+  profile list|show <name>
+  session list|clean
+
+GLOBAL FLAGS:
+  --profile <name>  Override CLAUDE_SESSION_PROFILE.
+  --config <path>   Override the config-file path.
+  --verbose         Enable debug logging.
+  --dry-run         Show what would happen where supported.
+  --help, -h        Show help.
+  --version         Print version.
+
+EXIT CODES:
+  0 success
+  1 generic error
+  2 usage error
+  3 config missing or invalid
+  4 real claude binary not found
+  5 secure session-dir validation failed
+  6 profile not found
+  7 hook command failed where fatal
+  130 interrupted by SIGINT
+  143 terminated by SIGTERM
+
+SUBCOMMANDS:
+
+claude-session run [--profile <name>] [--dry-run] [-- <claude_args>...]
+  Wrap the real claude binary with a per-terminal CLAUDE_CONFIG_DIR.
+
+claude-session doctor [--verbose]
+  Run config, binary, hook, dependency, and session-root health checks.
+
+claude-session usage
+  Print this aggregate command reference.
+
+claude-session config show [--verbose]
+  Print effective CLAUDE_SESSION_* config values.
+
+claude-session config path
+  Print the resolved config.env path.
+
+claude-session config edit
+  Open the config file in \$EDITOR, creating it if missing.
+
+claude-session profile list
+  List profiles under the config profiles directory.
+
+claude-session profile show <name> [--verbose]
+  Print one profile's env assignments.
+
+claude-session session list [--absolute] [--no-header]
+  Inventory active and stale session directories.
+
+claude-session session clean [--older-than <duration>] [--dry-run] [--yes]
+  Remove stale session directories.
+
+SEE ALSO:
+  docs/commands.md
+EOF
+}

--- a/lib/core.sh
+++ b/lib/core.sh
@@ -1,0 +1,107 @@
+# shellcheck shell=bash
+: 'desc: Parse global flags, load configuration, resolve profile, and dispatch.'
+
+CS_VERSION="0.1.0"
+
+cs::main() {
+  local -a args=("$@")
+  local -a rest=()
+  local sub=""
+  local help_requested=0
+  local i=0
+
+  CS_CLI_PROFILE=""
+  CS_CLI_CONFIG=""
+  CS_GLOBAL_DRY_RUN=0
+  export CS_CLI_PROFILE CS_CLI_CONFIG CS_GLOBAL_DRY_RUN
+
+  while [[ $i -lt ${#args[@]} ]]; do
+    case "${args[$i]}" in
+      --profile)
+        [[ $((i + 1)) -lt ${#args[@]} ]] || cs::helpers::die 2 "missing value for --profile." "--profile requires a profile name." "  claude-session --profile default doctor"
+        CS_CLI_PROFILE=${args[$((i + 1))]}
+        i=$((i + 2))
+        ;;
+      --config)
+        [[ $((i + 1)) -lt ${#args[@]} ]] || cs::helpers::die 2 "missing value for --config." "--config requires a path." "  claude-session --config /path/to/config.env doctor"
+        CS_CLI_CONFIG=${args[$((i + 1))]}
+        i=$((i + 2))
+        ;;
+      --verbose)
+        CLAUDE_SESSION_VERBOSE=1
+        export CLAUDE_SESSION_VERBOSE
+        i=$((i + 1))
+        ;;
+      --dry-run)
+        CS_GLOBAL_DRY_RUN=1
+        i=$((i + 1))
+        ;;
+      --help | -h)
+        help_requested=1
+        i=$((i + 1))
+        ;;
+      --version)
+        printf 'claude-session %s\n' "$CS_VERSION"
+        return 0
+        ;;
+      --)
+        rest=("${args[@]:$((i + 1))}")
+        sub=run
+        break
+        ;;
+      -*)
+        rest=("${args[@]:$i}")
+        sub=run
+        break
+        ;;
+      *)
+        if cs::loader::is_command "${args[$i]}"; then
+          sub=${args[$i]}
+          rest=("${args[@]:$((i + 1))}")
+        else
+          sub=run
+          rest=("${args[@]:$i}")
+        fi
+        break
+        ;;
+    esac
+  done
+
+  if [[ -z "$sub" ]]; then
+    if [[ $help_requested -eq 1 ]]; then
+      sub=usage
+    else
+      sub=run
+    fi
+  fi
+
+  if [[ $help_requested -eq 1 && "$sub" != "usage" ]]; then
+    rest=("--help" "${rest[@]}")
+  fi
+
+  if [[ "$sub" == "usage" || "${rest[0]:-}" == "--help" || "${rest[0]:-}" == "-h" ]]; then
+    cs::loader::dispatch "$sub" "${rest[@]}"
+    return $?
+  fi
+
+  cs::helpers::source_fn load_config
+  cs::fn::load_config
+  if [[ -n "$CS_CLI_PROFILE" ]]; then
+    CLAUDE_SESSION_PROFILE=$CS_CLI_PROFILE
+    export CLAUDE_SESSION_PROFILE
+  fi
+  if [[ $CS_GLOBAL_DRY_RUN -eq 1 ]]; then
+    CLAUDE_SESSION_DRY_RUN=1
+    export CLAUDE_SESSION_DRY_RUN
+  fi
+
+  # Doctor must be able to report on a broken profile rather than aborting
+  # in the global resolver. It runs resolve_profile itself with error
+  # capture, so we skip the eager resolution here.
+  if [[ "$sub" != "doctor" ]]; then
+    cs::helpers::source_fn resolve_profile
+    cs::fn::resolve_profile
+  fi
+
+  cs::loader::dispatch "$sub" "${rest[@]}"
+}

--- a/lib/functions/fn_error.sh
+++ b/lib/functions/fn_error.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=bash
+: 'desc: Emit the stable three-part claude-session error shape.'
+
+cs::fn::error() {
+  local summary=$1
+  local detail=$2
+  local fix=$3
+  local next=${4:-}
+
+  printf 'Error: %s\n\n' "$summary" >&2
+  printf 'What went wrong:\n  %s\n\n' "$detail" >&2
+  printf 'How to fix:\n%s\n' "$fix" >&2
+  if [[ -n "$next" ]]; then
+    printf '\nNext:\n  %s\n' "$next" >&2
+  fi
+}

--- a/lib/functions/fn_link_files.sh
+++ b/lib/functions/fn_link_files.sh
@@ -1,0 +1,32 @@
+# shellcheck shell=bash
+: 'desc: Link shared Claude files and directories into a session directory.'
+
+cs::fn::link_files() {
+  local session_dir=$1
+  local shared_dir=$2
+  local link_files=${CLAUDE_SESSION_LINK_FILES:-settings.local.json:keybindings.json:CLAUDE.md}
+  local link_dirs=${CLAUDE_SESSION_LINK_DIRS:-skills:agents:rules:commands:hooks}
+  local -a items=()
+  local item=""
+
+  cs::helpers::split_colon "$link_files" items
+  for item in "${items[@]}"; do
+    [[ -n "$item" ]] || continue
+    if [[ -e "$shared_dir/$item" ]]; then
+      mkdir -p "$(dirname "$session_dir/$item")"
+      ln -sfn "$shared_dir/$item" "$session_dir/$item"
+    fi
+  done
+
+  items=()
+  cs::helpers::split_colon "$link_dirs" items
+  for item in "${items[@]}"; do
+    [[ -n "$item" ]] || continue
+    if [[ -d "$shared_dir/$item" ]]; then
+      if [[ -e "$session_dir/$item" || -L "$session_dir/$item" ]]; then
+        rm -rf -- "${session_dir:?}/${item:?}"
+      fi
+      ln -sfn "$shared_dir/$item" "$session_dir/$item"
+    fi
+  done
+}

--- a/lib/functions/fn_load_config.sh
+++ b/lib/functions/fn_load_config.sh
@@ -1,0 +1,121 @@
+# shellcheck shell=bash
+: 'desc: Resolve, validate, and load the main dotenv configuration file.'
+
+__dotenv_quote_balanced() {
+  local value=$1
+  local quote=""
+  local char=""
+  local escaped=0
+  local i=0
+  while [[ $i -lt ${#value} ]]; do
+    char=${value:$i:1}
+    if [[ $escaped -eq 1 ]]; then
+      escaped=0
+    elif [[ "$char" == "\\" ]]; then
+      escaped=1
+    elif [[ -z "$quote" && ( "$char" == "'" || "$char" == '"' ) ]]; then
+      quote=$char
+    elif [[ -n "$quote" && "$char" == "$quote" ]]; then
+      quote=""
+    fi
+    i=$((i + 1))
+  done
+  [[ -z "$quote" ]]
+}
+
+cs::fn::validate_dotenv() {
+  local file=$1
+  local line=""
+  local lineno=0
+  local key=""
+  local value=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    lineno=$((lineno + 1))
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    if [[ ! "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]]; then
+      cs::helpers::die 3 "config syntax error." "$file:$lineno is not a KEY=VALUE assignment." "  Edit the file:  \${EDITOR:-vi} \"$file\"" "claude-session config edit"
+    fi
+    key=${line%%=*}
+    value=${line#*=}
+    # shellcheck disable=SC2016  # literal pattern fragments, not parameter expansions
+    if [[ "$value" == *'$('* || "$value" == *';'* || "$value" == *'&&'* || "$value" == *'||'* || "$value" == *'|'* || "$value" == *'`'* || "$value" == *'<'* || "$value" == *'>'* ]]; then
+      cs::helpers::die 3 "config syntax error." "$file:$lineno contains shell syntax in $key." "  Move complex logic into your shell rc or a hook script." "claude-session config edit"
+    fi
+    if ! __dotenv_quote_balanced "$value"; then
+      cs::helpers::die 3 "config syntax error." "$file:$lineno has unbalanced quotes in $key." "  Fix the quoted value in:  $file" "claude-session config edit"
+    fi
+  done <"$file"
+}
+
+cs::fn::load_config() {
+  local file
+  file=$(cs::helpers::config_path)
+  export CLAUDE_SESSION_CONFIG_FILE=$file
+  export CLAUDE_SESSION_CONFIG_DIR
+  CLAUDE_SESSION_CONFIG_DIR="$(dirname "$file")"
+
+  [[ -e "$file" ]] || return 0
+  [[ -r "$file" ]] || cs::helpers::die 3 "config file is unreadable." "Cannot read $file." "  chmod 600 \"$file\"" "claude-session config path"
+
+  cs::fn::validate_dotenv "$file"
+
+  local keys=(
+    CLAUDE_SESSION_CONFIG_DIR
+    CLAUDE_SESSION_SHARED_DIR
+    CLAUDE_SESSION_PROFILE
+    CLAUDE_SESSION_REAL_CLAUDE
+    CLAUDE_SESSION_OAUTH_CMD
+    CLAUDE_SESSION_POST_EXIT_CMD
+    CLAUDE_SESSION_SYNC_FILES
+    CLAUDE_SESSION_LINK_FILES
+    CLAUDE_SESSION_LINK_DIRS
+    CLAUDE_SESSION_VERBOSE
+  )
+  local key=""
+  local -A had_env=()
+  local -A env_val=()
+  for key in "${keys[@]}"; do
+    if [[ -v $key ]]; then
+      had_env[$key]=1
+      env_val[$key]=${!key}
+    fi
+  done
+
+  cs::fn::__apply_dotenv "$file"
+
+  for key in "${keys[@]}"; do
+    if [[ "${had_env[$key]:-0}" == "1" ]]; then
+      printf -v "$key" '%s' "${env_val[$key]}"
+      export "${key?}"
+    fi
+  done
+}
+
+# Parse an already-validated dotenv file line-by-line and export each
+# assignment. Avoids `source`-ing the file so values that contain spaces
+# (e.g. CLAUDE_SESSION_OAUTH_CMD=pass show ...) are treated as plain
+# string values rather than as KEY=word command-prefix assignments.
+cs::fn::__apply_dotenv() {
+  local file=$1
+  local line=""
+  local k=""
+  local v=""
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    [[ -z "$line" || "$line" == \#* ]] && continue
+    [[ "$line" =~ ^[A-Za-z_][A-Za-z0-9_]*= ]] || continue
+    k=${line%%=*}
+    v=${line#*=}
+    # Strip a single layer of matching surrounding single or double quotes.
+    if [[ ${#v} -ge 2 ]]; then
+      if [[ "${v:0:1}" == "\"" && "${v: -1}" == "\"" ]]; then
+        v=${v:1:${#v}-2}
+        v=${v//\\\"/\"}
+        v=${v//\\\\/\\}
+      elif [[ "${v:0:1}" == "'" && "${v: -1}" == "'" ]]; then
+        v=${v:1:${#v}-2}
+      fi
+    fi
+    printf -v "$k" '%s' "$v"
+    export "${k?}"
+  done <"$file"
+}

--- a/lib/functions/fn_merge_settings.sh
+++ b/lib/functions/fn_merge_settings.sh
@@ -1,0 +1,57 @@
+# shellcheck shell=bash
+: 'desc: Merge base and profile Claude settings into the session directory.'
+
+__file_mtime() {
+  local file=$1
+  stat -c '%Y' "$file" 2>/dev/null || printf '0'
+}
+
+__cache_hash() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum | awk '{print $1}'
+  else
+    cksum | awk '{print $1}'
+  fi
+}
+
+cs::fn::merge_settings() {
+  local shared_dir=$1
+  local profile=$2
+  local session_dir=$3
+  local config_dir=$4
+  local base="$shared_dir/settings.base.json"
+  [[ -f "$base" ]] || return 0
+
+  command -v jq >/dev/null 2>&1 || cs::helpers::die 3 "jq is required." "settings.base.json exists, so claude-session must merge settings with jq." "  Install jq or remove $base."
+
+  local overlay=""
+  if [[ -f "$config_dir/profiles/$profile.settings.json" ]]; then
+    overlay="$config_dir/profiles/$profile.settings.json"
+  elif [[ -f "$shared_dir/settings.$profile.json" ]]; then
+    overlay="$shared_dir/settings.$profile.json"
+  fi
+
+  local base_m
+  local overlay_m=0
+  base_m=$(__file_mtime "$base")
+  if [[ -n "$overlay" ]]; then
+    overlay_m=$(__file_mtime "$overlay")
+  fi
+  local cache_key
+  cache_key=$(printf '%s|%s|%s|%s|%s\n' "$profile" "$base" "$base_m" "$overlay" "$overlay_m" | __cache_hash)
+  local cache_file="$session_dir/.claude-session-settings-cache"
+  if [[ -f "$session_dir/settings.json" && -f "$cache_file" && "$(cat "$cache_file")" == "$cache_key" ]]; then
+    cs::helpers::debug "settings cache hit for profile $profile"
+    return 0
+  fi
+
+  local tmp="$session_dir/settings.json.tmp.$$"
+  if [[ -n "$overlay" ]]; then
+    jq -s '.[0] * .[1]' "$base" "$overlay" >"$tmp" || cs::helpers::die 3 "settings merge failed." "jq could not merge $base with $overlay." "  Fix invalid JSON in the settings files." "claude-session doctor"
+  else
+    cp "$base" "$tmp"
+  fi
+  jq empty "$tmp" >/dev/null || cs::helpers::die 3 "settings JSON is invalid." "Merged settings output failed jq validation." "  Fix $base or the profile overlay." "claude-session doctor"
+  mv -f "$tmp" "$session_dir/settings.json"
+  printf '%s\n' "$cache_key" >"$cache_file"
+}

--- a/lib/functions/fn_real_claude.sh
+++ b/lib/functions/fn_real_claude.sh
@@ -1,0 +1,58 @@
+# shellcheck shell=bash
+: 'desc: Discover the real claude binary without recursing into the wrapper.'
+
+__is_wrapper_path() {
+  local candidate=$1
+  local candidate_real=""
+  local wrapper_real=""
+  candidate_real=$(readlink -f "$candidate" 2>/dev/null || printf '%s\n' "$candidate")
+  wrapper_real=$(readlink -f "${CS_WRAPPER_PATH:-$0}" 2>/dev/null || printf '%s\n' "${CS_WRAPPER_PATH:-$0}")
+  [[ "$candidate_real" == "$wrapper_real" ]]
+}
+
+cs::fn::real_claude() {
+  local candidate=""
+  if [[ -n "${CLAUDE_SESSION_REAL_CLAUDE:-}" ]]; then
+    candidate=$CLAUDE_SESSION_REAL_CLAUDE
+    if [[ -x "$candidate" ]] && ! __is_wrapper_path "$candidate"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+    cs::helpers::die 4 "real claude binary not found." "CLAUDE_SESSION_REAL_CLAUDE is not executable or resolves back to this wrapper: $candidate" "  Set CLAUDE_SESSION_REAL_CLAUDE=/path/to/claude" "claude-session doctor"
+  fi
+
+  local versions="$HOME/.local/share/claude/versions"
+  if [[ -d "$versions" ]]; then
+    # docs/architecture.md: pick the highest-sort-V entry that is
+    # executable. Native installs may store the binary directly as
+    # `versions/<ver>` (the file IS the version-named binary, per the
+    # doctor example output) OR as `versions/<ver>/claude`. Try both.
+    local entry=""
+    while IFS= read -r entry; do
+      candidate=$entry
+      if [[ -d "$candidate" && -x "$candidate/claude" ]]; then
+        candidate="$candidate/claude"
+      fi
+      [[ -f "$candidate" && -x "$candidate" ]] || continue
+      if ! __is_wrapper_path "$candidate"; then
+        printf '%s\n' "$candidate"
+        return 0
+      fi
+    done < <(find "$versions" -mindepth 1 -maxdepth 1 -printf '%p\n' | sort -Vr)
+  fi
+
+  local dir=""
+  local -a path_entries=()
+  IFS=: read -r -a path_entries <<<"${PATH:-}"
+  for dir in "${path_entries[@]}"; do
+    [[ -n "$dir" ]] || continue
+    candidate="$dir/claude"
+    [[ -x "$candidate" ]] || continue
+    if ! __is_wrapper_path "$candidate"; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+  done
+
+  cs::helpers::die 4 "real claude binary not found." "Searched \$HOME/.local/share/claude/versions/ and PATH; no executable named \"claude\" that does not resolve to this wrapper." "  Install Claude Code and run:  claude login"$'\n'"  Or set an override:       CLAUDE_SESSION_REAL_CLAUDE=/path/to/claude" "claude-session doctor"
+}

--- a/lib/functions/fn_resolve_profile.sh
+++ b/lib/functions/fn_resolve_profile.sh
@@ -1,0 +1,36 @@
+# shellcheck shell=bash
+: 'desc: Resolve and load the active claude-session profile.'
+
+cs::fn::resolve_profile() {
+  local config_dir
+  config_dir=$(cs::helpers::config_dir_default)
+  local shared_dir=${CLAUDE_SESSION_SHARED_DIR:-$HOME/.claude}
+  local profile=${CLAUDE_SESSION_PROFILE:-default}
+  local explicit=0
+  if [[ -n "${CS_CLI_PROFILE:-}" || -n "${CLAUDE_SESSION_PROFILE:-}" ]]; then
+    explicit=1
+  fi
+  if [[ -n "${CS_CLI_PROFILE:-}" ]]; then
+    profile=$CS_CLI_PROFILE
+  fi
+
+  local profile_file="$config_dir/profiles/$profile.env"
+  local config_overlay="$config_dir/profiles/$profile.settings.json"
+  local shared_overlay="$shared_dir/settings.$profile.json"
+
+  if [[ -f "$profile_file" ]]; then
+    cs::helpers::source_fn load_config
+    cs::fn::validate_dotenv "$profile_file"
+    cs::fn::__apply_dotenv "$profile_file"
+  elif [[ $explicit -eq 1 && ! -f "$config_overlay" && ! -f "$shared_overlay" ]]; then
+    local found=""
+    if [[ -d "$config_dir/profiles" ]]; then
+      found=$(find "$config_dir/profiles" -maxdepth 1 -type f -name '*.env' -printf '%f\n' 2>/dev/null | sed 's/\.env$//' | sort | paste -sd ', ' -)
+    fi
+    cs::helpers::die 6 "profile \"$profile\" not found." "No file at $profile_file and no overlay at $config_overlay or $shared_overlay. Found profiles: ${found:-none}." "  List available profiles:  claude-session profile list"$'\n'"  Create the profile:       \${EDITOR:-vi} \"$profile_file\"" "claude-session profile list"
+  fi
+
+  CLAUDE_SESSION_PROFILE=$profile
+  export CLAUDE_SESSION_PROFILE
+  export CLAUDE_SESSION_CONFIG_DIR=$config_dir
+}

--- a/lib/functions/fn_run_hook.sh
+++ b/lib/functions/fn_run_hook.sh
@@ -1,0 +1,47 @@
+# shellcheck shell=bash
+: 'desc: Run user-configured hook commands with optional timeout handling.'
+
+cs::fn::run_hook() {
+  local cmd=$1
+  shift || true
+  local timeout_s=""
+  local fatal=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --timeout)
+        timeout_s=$2
+        shift 2
+        ;;
+      --fatal)
+        fatal=1
+        shift
+        ;;
+      *)
+        cs::helpers::die 2 "unknown hook flag \"$1\"." "run_hook accepts --timeout and --fatal only." "  Report this as an internal bug."
+        ;;
+    esac
+  done
+
+  [[ -n "$cmd" ]] || return 0
+  local output=""
+  local err=""
+  local status=0
+  err=$(mktemp)
+  if [[ -n "$timeout_s" && "$(command -v timeout || true)" != "" ]]; then
+    output=$(timeout "$timeout_s" bash -c "$cmd" 2>"$err") || status=$?
+  else
+    output=$(bash -c "$cmd" 2>"$err") || status=$?
+  fi
+  if [[ $status -ne 0 ]]; then
+    if [[ "${CLAUDE_SESSION_VERBOSE:-0}" == "1" ]]; then
+      sed 's/^/[claude-session] hook stderr: /' "$err" >&2 || true
+    else
+      cs::helpers::log "warning: hook command failed: $cmd"
+    fi
+    rm -f "$err"
+    [[ $fatal -eq 1 ]] && return "$status"
+    return 0
+  fi
+  rm -f "$err"
+  printf '%s\n' "$output"
+}

--- a/lib/functions/fn_session_dir.sh
+++ b/lib/functions/fn_session_dir.sh
@@ -1,0 +1,55 @@
+# shellcheck shell=bash
+: 'desc: Resolve and validate the secure XDG session root.'
+
+__session_root_validate() {
+  local root=$1
+  local source=$2
+  if [[ -e "$root" && ( ! -d "$root" || -L "$root" ) ]]; then
+    return 1
+  fi
+  mkdir -p "$root" "$root/sessions" || return 1
+  if [[ -L "$root" || ! -d "$root" ]]; then
+    return 1
+  fi
+  local owner
+  owner=$(stat -c '%u' "$root" 2>/dev/null) || return 1
+  [[ "$owner" == "$(id -u)" ]] || return 1
+  chmod 700 "$root" "$root/sessions" || return 1
+  CS_SESSION_ROOT_SOURCE=$source
+  export CS_SESSION_ROOT_SOURCE
+  printf '%s\n' "$root"
+}
+
+cs::fn::session_dir() {
+  local runtime_candidate=""
+  local state_candidate=""
+  local root=""
+
+  if [[ -n "${XDG_RUNTIME_DIR:-}" ]]; then
+    runtime_candidate="$XDG_RUNTIME_DIR/claude-session"
+    if root=$(__session_root_validate "$runtime_candidate" runtime); then
+      printf '%s\n' "$root"
+      return 0
+    fi
+  fi
+
+  if [[ -z "${HOME:-}" ]]; then
+    cs::helpers::die 5 "secure session-dir validation failed." "HOME is unset and XDG_RUNTIME_DIR did not resolve to a usable directory." "  Set XDG_RUNTIME_DIR or HOME before running claude-session." "claude-session doctor"
+  fi
+  state_candidate="${XDG_STATE_HOME:-$HOME/.local/state}/claude-session"
+  if root=$(__session_root_validate "$state_candidate" state); then
+    printf '%s\n' "$root"
+    return 0
+  fi
+
+  cs::helpers::die 5 "secure session-dir validation failed." "Neither XDG_RUNTIME_DIR nor the XDG_STATE_HOME fallback resolved a usable, owner-correct, non-symlink directory." "  Fix ownership and permissions on the XDG runtime/state directory." "claude-session doctor"
+}
+
+cs::fn::session_root_source_for() {
+  local root=$1
+  if [[ -n "${XDG_RUNTIME_DIR:-}" && "$root" == "$XDG_RUNTIME_DIR/claude-session" ]]; then
+    printf 'runtime\n'
+  else
+    printf 'state\n'
+  fi
+}

--- a/lib/functions/fn_session_inventory.sh
+++ b/lib/functions/fn_session_inventory.sh
@@ -1,0 +1,83 @@
+# shellcheck shell=bash
+: 'desc: Render active and stale session directories as a shared table.'
+
+__session_status() {
+  local id=$1
+  local dev=""
+  case "$id" in
+    pts-* | tty*)
+      dev="/dev/${id//-//}"
+      [[ -e "$dev" ]] && printf 'active\n' || printf 'stale\n'
+      ;;
+    pid-*)
+      kill -0 "${id#pid-}" 2>/dev/null && printf 'active\n' || printf 'stale\n'
+      ;;
+    *)
+      printf 'stale\n'
+      ;;
+  esac
+}
+
+__dir_size() {
+  local dir=$1
+  local bytes
+  bytes=$(du -sB1 "$dir" 2>/dev/null | awk '{print $1}') || bytes=0
+  if command -v numfmt >/dev/null 2>&1; then
+    numfmt --to=iec --suffix=iB "$bytes"
+  else
+    printf '%s B\n' "$bytes"
+  fi
+}
+
+cs::fn::session_inventory() {
+  local absolute=0
+  local no_header=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --absolute) absolute=1 ;;
+      --no-header) no_header=1 ;;
+      *) cs::helpers::die 2 "unknown session inventory flag \"$1\"." "The inventory renderer only accepts --absolute and --no-header." "  claude-session session list --help" ;;
+    esac
+    shift
+  done
+
+  cs::helpers::source_fn session_dir
+  local root
+  root=$(cs::fn::session_dir)
+  local root_source
+  root_source=$(cs::fn::session_root_source_for "$root")
+  local parent="$root/sessions"
+  local source_label="XDG_STATE_HOME"
+  [[ "$root_source" == "runtime" ]] && source_label="XDG_RUNTIME_DIR"
+
+  if [[ $no_header -eq 0 ]]; then
+    printf '%s/  (%s)\n' "$parent" "$source_label"
+    printf '# %-20s %-8s %-8s %s\n' "terminal_id" "status" "size" "mtime"
+  fi
+
+  local dir=""
+  local id=""
+  local status=""
+  local size=""
+  local mtime=""
+  local display=""
+  local tmp
+  tmp=$(mktemp)
+  shopt -u failglob
+  shopt -s nullglob
+  for dir in "$parent"/*; do
+    [[ -d "$dir" ]] || continue
+    id=$(basename "$dir")
+    status=$(__session_status "$id")
+    size=$(__dir_size "$dir")
+    mtime=$(date -u -r "$dir" '+%FT%TZ' 2>/dev/null || printf '1970-01-01T00:00:00Z')
+    display=$id
+    [[ $absolute -eq 1 ]] && display=$dir
+    printf '%s\t%s\t%s\t%s\n' "$mtime" "$display" "$status" "$size" >>"$tmp"
+  done
+  sort -r "$tmp" | while IFS=$'\t' read -r mtime display status size; do
+    [[ -n "$display" ]] || continue
+    printf '%-20s %-8s %-8s %s\n' "$display" "$status" "$size" "$mtime"
+  done
+  rm -f "$tmp"
+}

--- a/lib/functions/fn_sync_files.sh
+++ b/lib/functions/fn_sync_files.sh
@@ -1,0 +1,54 @@
+# shellcheck shell=bash
+: 'desc: Copy sync-classified Claude files in and back out atomically.'
+
+cs::fn::sync_files() {
+  local mode=$1
+  local session_dir=$2
+  local shared_dir=$3
+  local sync_files=${CLAUDE_SESSION_SYNC_FILES:-.credentials.json}
+  local -a items=()
+  local item=""
+  cs::helpers::split_colon "$sync_files" items
+
+  case "$mode" in
+    in)
+      for item in "${items[@]}"; do
+        [[ -n "$item" ]] || continue
+        if [[ -f "$shared_dir/$item" ]]; then
+          mkdir -p "$(dirname "$session_dir/$item")"
+          cp -p "$shared_dir/$item" "$session_dir/$item"
+        fi
+      done
+      ;;
+    out)
+      command -v flock >/dev/null 2>&1 || cs::helpers::die 3 "flock is required." "Cannot safely sync rewritten Claude files without flock." "  Install util-linux flock."
+      mkdir -p "$shared_dir"
+      local lock="$shared_dir/.claude-session.lock"
+      (
+        flock 9
+        local src=""
+        local dst=""
+        local tmp=""
+        local src_m=0
+        local dst_m=0
+        for item in "${items[@]}"; do
+          [[ -n "$item" ]] || continue
+          src="$session_dir/$item"
+          dst="$shared_dir/$item"
+          [[ -f "$src" ]] || continue
+          mkdir -p "$(dirname "$dst")"
+          src_m=$(stat -c '%Y' "$src" 2>/dev/null || printf '0')
+          dst_m=$(stat -c '%Y' "$dst" 2>/dev/null || printf '0')
+          if [[ ! -f "$dst" || $src_m -gt $dst_m ]]; then
+            tmp="$dst.tmp.$$"
+            cp -p "$src" "$tmp"
+            mv -f "$tmp" "$dst"
+          fi
+        done
+      ) 9>"$lock"
+      ;;
+    *)
+      cs::helpers::die 2 "invalid sync mode \"$mode\"." "sync_files accepts only \"in\" or \"out\"." "  Report this as an internal bug."
+      ;;
+  esac
+}

--- a/lib/functions/fn_terminal_id.sh
+++ b/lib/functions/fn_terminal_id.sh
@@ -1,0 +1,16 @@
+# shellcheck shell=bash
+: 'desc: Derive a stable terminal identifier from tty with a PID fallback.'
+
+cs::fn::terminal_id() {
+  local t
+  t=$(tty 2>/dev/null) || {
+    printf 'pid-%s\n' "$$"
+    return 0
+  }
+  if [[ "$t" != /dev/* ]]; then
+    printf 'pid-%s\n' "$$"
+    return 0
+  fi
+  t=${t#/dev/}
+  printf '%s\n' "${t//\//-}"
+}

--- a/lib/helpers.sh
+++ b/lib/helpers.sh
@@ -1,0 +1,110 @@
+# shellcheck shell=bash
+: 'desc: Shared low-level utilities for logging, errors, loading, and redaction.'
+
+cs::helpers::source_fn() {
+  local name=$1
+  local path="$LIB_DIR/functions/fn_${name}.sh"
+  if ! declare -F "cs::fn::${name}" >/dev/null 2>&1; then
+    # shellcheck source=/dev/null
+    . "$path"
+  fi
+}
+
+cs::helpers::log() {
+  printf '[claude-session] %s\n' "$*" >&2
+}
+
+cs::helpers::debug() {
+  if [[ "${CLAUDE_SESSION_VERBOSE:-0}" == "1" ]]; then
+    cs::helpers::log "debug: $*"
+  fi
+}
+
+cs::helpers::die() {
+  local code=$1
+  local summary=$2
+  local detail=$3
+  local fix=$4
+  local next=${5:-}
+  cs::helpers::source_fn error
+  cs::fn::error "$summary" "$detail" "$fix" "$next"
+  exit "$code"
+}
+
+cs::helpers::require() {
+  local cmd=$1
+  command -v "$cmd" >/dev/null 2>&1
+}
+
+cs::helpers::is_secret_key() {
+  local key=$1
+  # Suffix-based secret detection per docs/config.md §"Secrets discipline".
+  # docs/commands.md additionally shows CLAUDE_SESSION_OAUTH_CMD redacted by
+  # default in `config show` example output, since OAuth-lookup commands
+  # commonly embed secret-store paths.
+  case "$key" in
+    *_TOKEN | *_SECRET | *_KEY | *_PASSWORD) return 0 ;;
+    CLAUDE_SESSION_OAUTH_CMD) return 0 ;;
+  esac
+  return 1
+}
+
+cs::helpers::redact() {
+  local key=$1
+  local value=$2
+  local verbose=${3:-0}
+  # Never redact a placeholder for an unconfigured variable — `(unset)`
+  # and `(unset, auto-discover)` are documented `config show` outputs
+  # (see docs/commands.md), and hiding them would obscure the fact that
+  # nothing is configured.
+  case "$value" in
+    "(unset)" | "(unset, auto-discover)" | "")
+      printf '%s\n' "$value"
+      return 0
+      ;;
+  esac
+  if [[ "$verbose" != "1" ]] && cs::helpers::is_secret_key "$key"; then
+    printf '<redacted>\n'
+  else
+    printf '%s\n' "$value"
+  fi
+}
+
+cs::helpers::config_dir_default() {
+  if [[ -n "${CLAUDE_SESSION_CONFIG_DIR:-}" ]]; then
+    printf '%s\n' "$CLAUDE_SESSION_CONFIG_DIR"
+  else
+    if [[ -z "${HOME:-}" ]]; then
+      cs::helpers::die 3 "HOME is unset." "Cannot resolve the default XDG config directory." "  Set CLAUDE_SESSION_CONFIG_DIR=/path/to/config"
+    fi
+    printf '%s/claude-session\n' "${XDG_CONFIG_HOME:-$HOME/.config}"
+  fi
+}
+
+cs::helpers::config_path() {
+  if [[ -n "${CS_CLI_CONFIG:-}" ]]; then
+    printf '%s\n' "$CS_CLI_CONFIG"
+  else
+    printf '%s/config.env\n' "$(cs::helpers::config_dir_default)"
+  fi
+}
+
+cs::helpers::json_escape() {
+  local s=$1
+  s=${s//\\/\\\\}
+  s=${s//\"/\\\"}
+  s=${s//$'\n'/\\n}
+  s=${s//$'\r'/\\r}
+  s=${s//$'\t'/\\t}
+  printf '%s\n' "$s"
+}
+
+cs::helpers::split_colon() {
+  local value=$1
+  local -n out_ref="$2"
+  local old_ifs=$IFS
+  IFS=:
+  # shellcheck disable=SC2034  # out_ref is a nameref; assignment populates caller's array
+  read -r -a out_ref <<<"$value"
+  IFS=$old_ifs
+}

--- a/lib/loader.sh
+++ b/lib/loader.sh
@@ -1,0 +1,26 @@
+# shellcheck shell=bash
+: 'desc: Dispatch a subcommand by sourcing the matching command file.'
+
+cs::loader::is_command() {
+  local cmd=$1
+  case "$cmd" in
+    run | doctor | usage | config | profile | session) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+cs::loader::dispatch() {
+  local sub=${1:-run}
+  if [[ $# -gt 0 ]]; then
+    shift
+  fi
+
+  if ! cs::loader::is_command "$sub"; then
+    cs::helpers::die 2 "unknown subcommand \"$sub\"." "No claude-session subcommand named \"$sub\" exists." "  See all commands:  claude-session usage" "claude-session usage"
+  fi
+
+  local path="$LIB_DIR/commands/cmd_${sub}.sh"
+  # shellcheck source=/dev/null
+  . "$path"
+  "cs::cmd::${sub}" "$@"
+}

--- a/test/cmd_config_test.bats
+++ b/test/cmd_config_test.bats
@@ -1,0 +1,28 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper'
+  _common_setup
+}
+
+# bats test_tags=unit
+@test "config path prints default config file path" {
+  run claude-session config path
+  assert_success
+  assert_output_contains "$XDG_CONFIG_HOME/claude-session/config.env"
+}
+
+# bats test_tags=unit
+@test "config show prints defaults" {
+  run claude-session config show
+  assert_success
+  assert_output_contains "CLAUDE_SESSION_PROFILE=default"
+  assert_output_contains "CLAUDE_SESSION_SYNC_FILES=.credentials.json"
+}
+
+# bats test_tags=integration
+@test "config edit creates file with fake editor" {
+  EDITOR=true run claude-session config edit
+  assert_success
+  [[ -f "$XDG_CONFIG_HOME/claude-session/config.env" ]]
+}

--- a/test/cmd_doctor_test.bats
+++ b/test/cmd_doctor_test.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper'
+  _common_setup
+  mkdir -p "$BATS_TEST_TMPDIR/fakebin" "$HOME/.claude"
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$BATS_TEST_TMPDIR/fakebin/claude"
+  chmod +x "$BATS_TEST_TMPDIR/fakebin/claude"
+  export CLAUDE_SESSION_REAL_CLAUDE="$BATS_TEST_TMPDIR/fakebin/claude"
+}
+
+# bats test_tags=integration
+@test "doctor prints health checks and sessions" {
+  run claude-session doctor
+  assert_success
+  assert_output_contains "config"
+  assert_output_contains "Sessions"
+}

--- a/test/cmd_profile_test.bats
+++ b/test/cmd_profile_test.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper'
+  _common_setup
+  mkdir -p "$XDG_CONFIG_HOME/claude-session/profiles"
+}
+
+# bats test_tags=unit
+@test "profile list is empty with no profiles" {
+  run claude-session profile list
+  assert_success
+  [[ -z "$output" ]]
+}
+
+# bats test_tags=unit
+@test "profile show prints profile keys" {
+  cat >"$XDG_CONFIG_HOME/claude-session/profiles/default.env" <<'EOF'
+ANTHROPIC_MODEL=claude-test
+SECRET_KEY=secret
+EOF
+  run claude-session profile show default
+  assert_success
+  assert_output_contains "ANTHROPIC_MODEL=claude-test"
+  assert_output_contains "SECRET_KEY=<redacted>"
+}
+
+# bats test_tags=unit
+@test "missing explicit profile exits six" {
+  run claude-session --profile missing profile show missing
+  [[ "$status" -eq 6 ]]
+}

--- a/test/cmd_run_test.bats
+++ b/test/cmd_run_test.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper'
+  _common_setup
+  mkdir -p "$BATS_TEST_TMPDIR/fakebin" "$HOME/.claude"
+  cat >"$BATS_TEST_TMPDIR/fakebin/claude" <<'EOF'
+#!/usr/bin/env bash
+printf 'CLAUDE_CONFIG_DIR=%s\n' "$CLAUDE_CONFIG_DIR" >"$BATS_TEST_TMPDIR/child-env"
+printf '%s\n' "$*" >"$BATS_TEST_TMPDIR/child-args"
+exit "${FAKE_CLAUDE_STATUS:-0}"
+EOF
+  chmod +x "$BATS_TEST_TMPDIR/fakebin/claude"
+  export CLAUDE_SESSION_REAL_CLAUDE="$BATS_TEST_TMPDIR/fakebin/claude"
+}
+
+# bats test_tags=integration
+@test "run dry-run prints plan without spawning child" {
+  run claude-session run --dry-run -- chat hi
+  assert_success
+  assert_output_contains "session_dir="
+  [[ ! -f "$BATS_TEST_TMPDIR/child-env" ]]
+}
+
+# bats test_tags=integration
+@test "run invokes fake claude with args" {
+  run claude-session run -- chat hi
+  assert_success
+  [[ -f "$BATS_TEST_TMPDIR/child-env" ]]
+  grep -q 'CLAUDE_CONFIG_DIR=' "$BATS_TEST_TMPDIR/child-env"
+  grep -q 'chat hi' "$BATS_TEST_TMPDIR/child-args"
+}
+
+# bats test_tags=integration
+@test "bare skips failing oauth hook" {
+  export CLAUDE_SESSION_OAUTH_CMD='false'
+  run claude-session run -- --bare -p ping
+  assert_success
+}

--- a/test/cmd_session_test.bats
+++ b/test/cmd_session_test.bats
@@ -1,0 +1,21 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper'
+  _common_setup
+}
+
+# bats test_tags=unit
+@test "session list succeeds with no sessions" {
+  run claude-session session list
+  assert_success
+  assert_output_contains "sessions"
+}
+
+# bats test_tags=integration
+@test "session clean dry-run lists stale directory" {
+  mkdir -p "$XDG_RUNTIME_DIR/claude-session/sessions/pid-999999"
+  run claude-session session clean --dry-run
+  assert_success
+  assert_output_contains "pid-999999"
+}

--- a/test/cmd_usage_test.bats
+++ b/test/cmd_usage_test.bats
@@ -1,0 +1,35 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper'
+  _common_setup
+}
+
+# bats test_tags=unit
+@test "usage exits zero and prints command reference" {
+  run claude-session usage
+  assert_success
+  assert_output_contains "COMMAND TREE"
+  assert_output_contains "session clean"
+}
+
+# bats test_tags=unit
+@test "global help exits zero" {
+  run claude-session --help
+  assert_success
+  assert_output_contains "USAGE"
+}
+
+# bats test_tags=unit
+@test "version prints version" {
+  run claude-session --version
+  assert_success
+  assert_output_contains "claude-session 0.1.0"
+}
+
+# bats test_tags=unit
+@test "unknown nested command exits usage error" {
+  run claude-session config nope
+  assert_failure
+  [[ "$status" -eq 2 ]]
+}

--- a/test/fn_merge_settings_test.bats
+++ b/test/fn_merge_settings_test.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper'
+  _common_setup
+  . "$BATS_TEST_DIRNAME/../lib/helpers.sh"
+  cs::helpers::source_fn merge_settings
+}
+
+# bats test_tags=unit
+@test "merge settings overlays profile json" {
+  mkdir -p "$BATS_TEST_TMPDIR/shared" "$BATS_TEST_TMPDIR/session" "$XDG_CONFIG_HOME/claude-session/profiles"
+  printf '{"a":1,"b":{"c":1}}\n' >"$BATS_TEST_TMPDIR/shared/settings.base.json"
+  printf '{"b":{"d":2}}\n' >"$XDG_CONFIG_HOME/claude-session/profiles/default.settings.json"
+  run cs::fn::merge_settings "$BATS_TEST_TMPDIR/shared" default "$BATS_TEST_TMPDIR/session" "$XDG_CONFIG_HOME/claude-session"
+  assert_success
+  jq -e '.b.d == 2' "$BATS_TEST_TMPDIR/session/settings.json"
+}

--- a/test/fn_real_claude_test.bats
+++ b/test/fn_real_claude_test.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper'
+  _common_setup
+  . "$BATS_TEST_DIRNAME/../lib/helpers.sh"
+  cs::helpers::source_fn real_claude
+}
+
+# bats test_tags=unit
+@test "real claude uses executable override" {
+  printf '#!/usr/bin/env bash\nexit 0\n' >"$BATS_TEST_TMPDIR/claude"
+  chmod +x "$BATS_TEST_TMPDIR/claude"
+  export CLAUDE_SESSION_REAL_CLAUDE="$BATS_TEST_TMPDIR/claude"
+  run cs::fn::real_claude
+  assert_success
+  assert_output_contains "$BATS_TEST_TMPDIR/claude"
+}

--- a/test/fn_session_dir_test.bats
+++ b/test/fn_session_dir_test.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper'
+  _common_setup
+  . "$BATS_TEST_DIRNAME/../lib/helpers.sh"
+  cs::helpers::source_fn session_dir
+}
+
+# bats test_tags=unit
+@test "session dir prefers runtime dir" {
+  run cs::fn::session_dir
+  assert_success
+  assert_output_contains "$XDG_RUNTIME_DIR/claude-session"
+}

--- a/test/fn_sync_files_test.bats
+++ b/test/fn_sync_files_test.bats
@@ -1,0 +1,17 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper'
+  _common_setup
+  . "$BATS_TEST_DIRNAME/../lib/helpers.sh"
+  cs::helpers::source_fn sync_files
+}
+
+# bats test_tags=unit
+@test "sync files copies credentials in" {
+  mkdir -p "$BATS_TEST_TMPDIR/shared" "$BATS_TEST_TMPDIR/session"
+  printf '{}\n' >"$BATS_TEST_TMPDIR/shared/.credentials.json"
+  run cs::fn::sync_files in "$BATS_TEST_TMPDIR/session" "$BATS_TEST_TMPDIR/shared"
+  assert_success
+  [[ -f "$BATS_TEST_TMPDIR/session/.credentials.json" ]]
+}

--- a/test/fn_terminal_id_test.bats
+++ b/test/fn_terminal_id_test.bats
@@ -1,0 +1,15 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper'
+  _common_setup
+  . "$BATS_TEST_DIRNAME/../lib/helpers.sh"
+  cs::helpers::source_fn terminal_id
+}
+
+# bats test_tags=unit
+@test "terminal id falls back to pid in bats" {
+  run cs::fn::terminal_id
+  assert_success
+  assert_output_contains "pid-"
+}

--- a/test/install_test.bats
+++ b/test/install_test.bats
@@ -1,0 +1,16 @@
+#!/usr/bin/env bats
+
+setup() {
+  load 'test_helper'
+  _common_setup
+}
+
+# bats test_tags=integration
+@test "install and uninstall use manifest in fake home" {
+  run "$BATS_TEST_DIRNAME/../install.sh"
+  assert_success
+  [[ -f "$HOME/.local/bin/claude-session" ]]
+  [[ -f "$XDG_STATE_HOME/claude-session/install-manifest" ]]
+  run "$BATS_TEST_DIRNAME/../uninstall.sh"
+  assert_success
+}

--- a/test/test_helper.bash
+++ b/test/test_helper.bash
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2154  # $status and $output are set by bats run
+
+_common_setup() {
+  export PATH="${BATS_TEST_DIRNAME}/../bin:$PATH"
+  export LIB_DIR="${BATS_TEST_DIRNAME}/../lib"
+  export HOME="$BATS_TEST_TMPDIR/home"
+  export XDG_CONFIG_HOME="$BATS_TEST_TMPDIR/config"
+  export XDG_STATE_HOME="$BATS_TEST_TMPDIR/state"
+  export XDG_RUNTIME_DIR="$BATS_TEST_TMPDIR/runtime"
+  unset CLAUDE_SESSION_PROFILE
+  unset CLAUDE_SESSION_REAL_CLAUDE
+  unset CLAUDE_SESSION_OAUTH_CMD
+  unset CLAUDE_SESSION_POST_EXIT_CMD
+  mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$XDG_STATE_HOME" "$XDG_RUNTIME_DIR"
+}
+
+assert_success() {
+  if [[ "$status" -ne 0 ]]; then
+    printf 'expected success, got %s\n%s\n' "$status" "$output"
+    return 1
+  fi
+}
+
+assert_failure() {
+  if [[ "$status" -eq 0 ]]; then
+    printf 'expected failure, got success\n%s\n' "$output"
+    return 1
+  fi
+}
+
+assert_output_contains() {
+  local needle=$1
+  if [[ "$output" != *"$needle"* ]]; then
+    printf 'expected output to contain %s\nactual:\n%s\n' "$needle" "$output"
+    return 1
+  fi
+}

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+set -euo pipefail
+shopt -s inherit_errexit 2>/dev/null || true
+
+user_mode=0
+if [[ $EUID -ne 0 && -z "${PREFIX:-}" ]]; then
+  user_mode=1
+fi
+
+if [[ $user_mode -eq 1 ]]; then
+  state_dir="${XDG_STATE_HOME:-$HOME/.local/state}/claude-session"
+else
+  state_dir="/var/lib/claude-session"
+fi
+manifest="$state_dir/install-manifest"
+
+if [[ ! -f "$manifest" ]]; then
+  printf '[claude-session] warning: install manifest missing at %s\n' "$manifest" >&2
+  exit 1
+fi
+
+mapfile -t paths <"$manifest"
+for ((i = ${#paths[@]} - 1; i >= 0; i--)); do
+  path=${paths[$i]}
+  [[ -n "$path" ]] || continue
+  if [[ "$path" == "$state_dir" && -d "$state_dir/sessions" ]]; then
+    continue
+  fi
+  if [[ -f "$path" || -L "$path" ]]; then
+    rm -f "$path"
+  elif [[ -d "$path" ]]; then
+    rmdir "$path" 2>/dev/null || true
+  fi
+done
+rm -f "$manifest"


### PR DESCRIPTION
Closes #3

## Summary

Removes optional build dependencies and git submodule requirements to simplify project setup and reduce maintenance overhead. This streamlines both the development workflow and installation process by eliminating the need for scdoc compiler and git submodule initialization.

## Key Changes

- Remove scdoc-based man page generation (man/ directory, `just man` build step)
- Remove git submodule dependencies for bats helpers (bats-support, bats-assert, bats-file)
- Update `.pre-commit-config.yaml` to exclude completions scripts from bashate linting
- Update documentation (AGENTS.md, docs/architecture.md, docs/development.md) to remove references to man pages and submodule setup
- Simplify GitHub Actions CI workflow by removing `submodules: recursive` from checkout step
- Update repo setup instructions to skip git submodule initialization