### PR TITLE
fix(ci): make the gated pipeline parse and its push lane hermetic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,10 +148,15 @@ jobs:
     needs: [lint, test, build, supply-chain, flake, dist-plan]
     steps:
       - name: Every needed job succeeded
+        env:
+          # A GitHub expression takes single-quoted string literals only; the
+          # double-quoted separator made the whole workflow file unparsable.
+          # The results reach the step through the environment, so no result
+          # value is interpolated into the shell.
+          RESULTS: ${{ join(needs.*.result, ' ') }}
         run: |
           set -euo pipefail
-          results='${{ join(needs.*.result, " ") }}'
-          echo "needed results: $results"
-          for result in $results; do
+          echo "needed results: $RESULTS"
+          for result in $RESULTS; do
             [ "$result" = success ] || { echo "a needed job reported $result"; exit 1; }
           done

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -21,6 +21,20 @@ rustPlatform.buildRustPackage {
   src = lib.cleanSource ../.;
   cargoLock.lockFile = ../Cargo.lock;
 
+  # The integration lane needs a controlling terminal and the recording stub
+  # (docs/reference/testing-and-quality.md), and the Nix sandbox offers
+  # neither, so `cargo test` here fails on eighteen login tests that pass
+  # everywhere the lane is actually run. This derivation's job is to prove the
+  # crate builds; the `test` job of the gated pipeline and `just hooks` own
+  # whether it works.
+  doCheck = false;
+
+  # One cheap proof that the built binary runs at all, which is what doCheck
+  # would otherwise have given for free.
+  postInstall = ''
+    $out/bin/${package.name} --version
+  '';
+
   meta = {
     # The first [[bin]] name where one is declared, else the package
     # name — the implicit src/main.rs binary. nix run resolves the

--- a/tests/accounts.rs
+++ b/tests/accounts.rs
@@ -1527,8 +1527,20 @@ fn the_binding_outranks_user_configuration_and_yields_to_the_project_layer() {
         "default_profile = \"tree\"\n",
     )
     .expect("project config");
+    // Clear git's own environment. A git hook exports GIT_DIR and GIT_WORK_TREE
+    // to everything it runs, so under `git push` this `init` would adopt the
+    // repository's git directory instead of creating one in the fixture, and the
+    // project layer would have no tree boundary to be discovered from. In a
+    // linked worktree GIT_DIR is absolute, so it resolves from the fixture's
+    // directory and the test fails; in the main checkout it is relative, does
+    // not resolve, and the test passes. Only clearing makes the lane honest.
     std::process::Command::new("git")
         .args(["init", "-q"])
+        .env_remove("GIT_DIR")
+        .env_remove("GIT_WORK_TREE")
+        .env_remove("GIT_INDEX_FILE")
+        .env_remove("GIT_COMMON_DIR")
+        .env_remove("GIT_CEILING_DIRECTORIES")
         .current_dir(harness.root())
         .status()
         .expect("git init");


### PR DESCRIPTION
The gate job the trunk protection names carried a double-quoted separator
inside a GitHub expression. Expressions take single-quoted string literals
only, so the whole workflow file was unparsable and every run failed at
startup rather than at a job. The results now reach the step through the
environment, which also keeps a result value off the shell command line.

The push lane then failed on `the_binding_outranks_user_configuration_and_yields_to_the_project_layer`.
A git hook exports `GIT_DIR` and `GIT_WORK_TREE` to everything it runs, so
under `git push` the fixture's `git init` adopted the repository's git
directory instead of creating one in the temporary tree, and the project
layer had no boundary to be discovered from. In the main checkout `GIT_DIR`
is relative and does not resolve from the fixture, which is why the test
passed there; in a linked worktree it is absolute, so the failure was
reliable. The invocation now clears git's variables.