### PR TITLE
chore(repo): ignore the per-checkout envrc override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ rustc-ice-*.txt
 # Nix devshell
 .direnv/
 /result
+# Per-checkout direnv overrides: the release bootstrap's coordinates, and the
+# RK_DEVSHELL_SYNC switch. Machine-local by definition, so never committed.
+/.envrc.local
 # Drafts: a workshop, never shipped. Promotion out of .draft/ is a rewrite into
 # the owning doc, not a move. See docs/decisions/ADR-0077-add-a-plan-zone-to-reader-need-docs.md.
 .draft/


### PR DESCRIPTION
The release bootstrap keeps its coordinates in a per-checkout `.envrc.local`, the same shape release-kit's own repository uses, and `RK_DEVSHELL_SYNC=0` lives there too. Both are machine-local, so the file is ignored rather than committed.