### PR TITLE
chore(nix): move the rk devshell pin to v0.3.3

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -42,16 +42,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1788892367,
-        "narHash": "sha256-FXOv6no3THbqwwnx9AvXqHBrw/3CWN+qiYEA8S2nSBM=",
+        "lastModified": 1788896309,
+        "narHash": "sha256-3Ok1/lmjSiSc2xaI1qp4WVoj8TNR+nuyIJ266vV0M6M=",
         "owner": "gubasso",
         "repo": "release-kit",
-        "rev": "ccd7bff6d3f830e002ebf349b10d976a512d6267",
+        "rev": "3ee4388c1c74e5eb2f98ad46d5b6ff4a2f2ccf05",
         "type": "github"
       },
       "original": {
         "owner": "gubasso",
-        "ref": "v0.3.2",
+        "ref": "v0.3.3",
         "repo": "release-kit",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     # pin and the lock together, so the project supplies its own `rk` instead of
     # depending on a host install.
     release-kit = {
-      url = "github:gubasso/release-kit/v0.3.2";
+      url = "github:gubasso/release-kit/v0.3.3";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
The daily `.envrc` sync moved the pin and refreshed the lock, and proved the build before writing either. This is that two-file change, reviewed and landed.