### PR TITLE
fix(release): keep the generated changelog free of emphasis

### DIFF
--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -68,6 +68,8 @@ semver_check = false
 
 `semver_check` is disabled only because the `claude_session` library target exists for this crate's own tests and no external consumer holds that API. The CLI compatibility is still versioned. `git_release_enable` is false because cargo-dist creates the GitHub Release, being the half that has the installers to attach.
 
+A `[changelog]` section carries two postprocessors. The default template writes the scope as `*(scope)*` and the breaking marker as `[**breaking**]`, and `AGENTS.md` forbids decorative emphasis in every Markdown file, the generated changelog included. Without them the repository contract fails on the release request and no release can merge.
+
 ## Package metadata and contents
 
 `Cargo.toml` owns all live package metadata and the anchored `exclude` denylist. Verify both buildability and contents:

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -17,3 +17,18 @@ git_release_enable = false
 # tests can link it, and no external consumer holds that API. The shipped
 # surface is the binary. Set true if the library ever gains outside consumers.
 semver_check = false
+
+[changelog]
+# The default body template writes the scope as `*(scope)*` and the breaking
+# marker as `[**breaking**]`. AGENTS.md forbids decorative emphasis, and the
+# `every_markdown_file_is_free_of_decorative_emphasis` contract scans every
+# Markdown file in the tree, so a generated changelog carrying either fails the
+# gate on the release request and no release can merge.
+#
+# These edit the rendered text rather than replacing `body`. A copy of
+# release-plz's own template would silently drift from it at every upgrade,
+# where two rules that match nothing are visible in the request's diff.
+postprocessors = [
+  { pattern = '\*\(([^)]*)\)\*', replace = "(${1})" },
+  { pattern = '\[\*\*breaking\*\*\]', replace = "[breaking]" },
+]


### PR DESCRIPTION
The first release request failed its own gate. release-plz's default body
template writes the scope as \`*(scope)*\` and the breaking marker as
\`[**breaking**]\`, and \`AGENTS.md\` forbids decorative emphasis in every
Markdown file, which the \`every_markdown_file_is_free_of_decorative_emphasis\`
contract enforces over the whole tree. So the generated \`CHANGELOG.md\` failed
the required check and no release could merge.

Two postprocessors edit the rendered text. Replacing \`body\` outright would
mean carrying a copy of release-plz's own template that drifts from it at
every upgrade, where a rule matching nothing is visible in the request's diff.