### PR TITLE
fix(release): define the dist profile and tag under the protected prefix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,6 +78,14 @@ assert_cmd = "2.2.2"
 insta = "1.48.0"
 tempfile = "3.27.0"
 
+# The profile cargo-dist builds release artifacts with. `dist generate` writes
+# the workflow but never this block, so without it every artifact build fails
+# on "profile `dist` is not defined" after the source publish has already
+# happened, leaving a release with no binaries.
+[profile.dist]
+inherits = "release"
+lto = "thin"
+
 [lints.rust]
 unsafe_code = "forbid"
 unused_must_use = "deny"

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -60,11 +60,14 @@ The live `[workspace]` policy is:
 
 ```toml
 changelog_update = true
+git_tag_name = "v{{ version }}"
 release_always = false
 publish = true
 git_release_enable = false
 semver_check = false
 ```
+
+`git_tag_name` is explicit because this manifest is a workspace root with an `xtask` member, so release-plz's default would be `claude-session-v{{ version }}`. The `release-tags` ruleset protects `refs/tags/v*`, and a tag outside that pattern is deletable and movable.
 
 `semver_check` is disabled only because the `claude_session` library target exists for this crate's own tests and no external consumer holds that API. The CLI compatibility is still versioned. `git_release_enable` is false because cargo-dist creates the GitHub Release, being the half that has the installers to attach.
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,11 @@
 [workspace]
 changelog_update = true
+# This manifest is a workspace root with an `xtask` member, so release-plz's
+# default tag is `claude-session-v{{ version }}`. The `release-tags` ruleset
+# protects `refs/tags/v*`, which that form does not match, so every release
+# tag was deletable and movable. The v-prefixed form is what the convention
+# protects.
+git_tag_name = "v{{ version }}"
 # The bot's own release request has a release-plz-* head branch, which is
 # exactly what the branch heuristic behind this default recognizes: the
 # release half fires only on the push that lands that request's bump, so an


### PR DESCRIPTION
The 0.1.1 release published to crates.io and then shipped no binaries. Two
defects in the same configuration, found by running it.

`Cargo.toml` carried no `[profile.dist]`. `dist generate` writes the workflow
but never that block, so `build-local-artifacts` failed on "profile `dist` is
not defined" after the source publish had already happened, leaving a release
with no archive, no installer, and no attestation. `dist plan` now lists the
whole artifact set.

release-plz tagged `claude-session-v0.1.1`, its default for a workspace root
with a second member. The `release-tags` ruleset protects `refs/tags/v*`, which
that form does not match, so the tag was deletable and movable. `git_tag_name`
is now explicit.

`claude-session-v0.1.1` keeps its name; the next release tags `v0.1.2`.