### PR TITLE
fix(release): match the changelog header to the markdown formatter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
-and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -25,6 +25,19 @@ git_release_enable = false
 semver_check = false
 
 [changelog]
+# The default header hard-wraps its last sentence across two lines, and the
+# `dprint fmt (markdown)` hook unwraps it. Left alone, every release rewrote
+# the header wrapped and the next `just hooks` unwrapped it again, so the
+# trunk was dirty after each release. This is the default text with that one
+# sentence on a single line.
+header = """# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+"""
 # The default body template writes the scope as `*(scope)*` and the breaking
 # marker as `[**breaking**]`. AGENTS.md forbids decorative emphasis, and the
 # `every_markdown_file_is_free_of_decorative_emphasis` contract scans every


### PR DESCRIPTION
Found by running `just hooks` on a clean trunk after the 0.1.3 release: it
reported `CHANGELOG.md` modified.

release-plz's default changelog header hard-wraps its last sentence across two
lines. The `dprint fmt (markdown)` hook unwraps it. So every release rewrote
the header wrapped, and the next `just hooks` unwrapped it again, leaving the
trunk dirty after each release against a gate `AGENTS.md` requires to be green
before proposing changes. CI never caught it, because `just fmt-check` covers
`cargo fmt` and `taplo` only.

The `header` value is release-plz's own default text with that one sentence on
a single line, and the committed `CHANGELOG.md` is brought to the same shape.