### PR TITLE
docs(reference): retell the record now that releases exist

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -20,3 +20,4 @@
 - For contribution procedure, use the [development workflow](./guides/development-workflow.md) and [testing gate](./reference/testing-and-quality.md#the-gate).
 - For release operations, use the [release guide](./guides/releasing.md) and [release contract](./reference/release-workflow.md).
 - For externally owned facts, consult [research tracking](./reference/research-tracking.yaml) before relying on a measured child behavior.
+- For a workaround that looks unexplained, read [known issues](./reference/known-issues/), which records the upstream defect behind it.

--- a/docs/decisions/ADR-0022-cut-the-first-release-when-passthrough-works.md
+++ b/docs/decisions/ADR-0022-cut-the-first-release-when-passthrough-works.md
@@ -2,7 +2,7 @@
 
 ## Context and Problem Statement
 
-The crate builds a placeholder binary, but the release machinery is already wired: `release-plz.toml`, the helper scripts under `scripts/`, and [the release runbook](../guides/releasing.md) could publish today. crates.io versions are immutable — a published version can be yanked but never replaced — so the timing of the first upload is a one-way door. It also decides what `README.md` may promise and which guides can honestly be written.
+The crate builds a placeholder binary, but the release machinery is wired and could publish today. crates.io versions are immutable, because a published version can be yanked but never replaced, so the timing of the first upload is a one-way door. It also decides what `README.md` can promise and which guides can honestly be written.
 
 ## Considered Options
 
@@ -19,15 +19,15 @@ Chosen option: publish nothing until passthrough works. The crate's description 
 ## Consequences
 
 - Good: every published version does what the crate description says, so nothing needs yanking.
-- Good: one rule governs what user-facing documentation may promise — nothing until `0.1.0` exists. The `guides/` zone stays at its contributor guide rather than filling with tasks no reader can verify.
+- Good: one rule governs what user-facing documentation can promise, which is nothing until `0.1.0` exists.
 - Bad: the crate name is unreserved until then.
 - Bad: release-plz and Trusted Publishing get their first end-to-end exercise on the real `0.1.0` rather than on a throwaway version.
 
 ## Status
 
-Accepted
+Implemented
 
-`Cargo.toml` holds `0.1.0` as the unreleased authoring version; the tag that mirrors it does not exist yet.
+The project published `0.1.0` on 2026-09-08, after the wrapper forwarded argv, standard streams, and the child's exit status. The trunk carries `0.1.4`, and no version was yanked. [The changelog](../../CHANGELOG.md) records every release.
 
 Documentation timing now follows [ADR-0075](./ADR-0075-build-through-the-current-slice.md). The release decision recorded here is unchanged.
 

--- a/docs/reference/cli-surface.md
+++ b/docs/reference/cli-surface.md
@@ -19,7 +19,7 @@ When the first non-flag token is a wrapper verb, the invocation is a wrapper com
 
 This table is the denylist. Every flag on it is intercepted by the wrapper in leading position and does not reach the child there. Every flag not on it is forwarded verbatim, whether or not the wrapper recognizes it, and whether or not it exists in the child.
 
-The child-status column is measured, not assumed. It is the intersection audited by [ADR-0044](../decisions/ADR-0044-audit-wrapper-spellings-against-the-child-inventory.md), taken from `claude` 2.1.220 on 2026-08-06 and recorded in [the child inventory](../../tests/fixtures/child-inventory.yaml); the `child-flag-and-verb-inventory` fact in [research tracking](./research-tracking.yaml) owns its freshness.
+The child-status column is measured, not assumed. It is the intersection audited by [ADR-0044](../decisions/ADR-0044-audit-wrapper-spellings-against-the-child-inventory.md), taken from `claude` 2.1.220 on 2026-08-06 and recorded in [the child inventory](../../tests/fixtures/child-inventory.yaml). This page's own entry in [research tracking](./research-tracking.yaml) owns that measurement's freshness.
 
 | Flag               | Meaning                                              | Why the wrapper claims it                                                                                                   | Child status                              |
 | ------------------ | ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- |
@@ -214,7 +214,7 @@ The page states an `about` and a version that `--help` never shows, because the 
 
 ## Version output
 
-`--version` and the `version` verb compose wrapper and child output on standard output:
+`--version` and the `version` verb compose wrapper and child output on standard output. The numbers in this section illustrate the shape and state no current version: the wrapper reads its own from `Cargo.toml` at build time, and the child's from the child.
 
 ```text
   This is claude-session 0.1.0.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -188,7 +188,7 @@ Pieces are folded left to right into one document:
 
 Array strategy is the one genuinely contested decision. Replace is the default because it is predictable: what the last piece says is what you get. Concatenation is what you want for additive lists — extra permitted paths, extra tools — and it is opt-in per key through a strategy table in the profile, because a global concat setting is wrong for roughly half of any real settings file.
 
-Worth knowing before it surprises a piece author: the child merges arrays the other way. Where one array-valued setting appears in several of the child's own scopes, the child concatenates and de-duplicates rather than replacing. The wrapper's pieces are not the child's scopes, and predictability wins inside the wrapper — but a `permissions.allow` split across two pieces behaves differently from the same list split across two of the child's files. The child's rule is tracked as [`child-settings-scope-precedence`](./research-tracking.yaml).
+Worth knowing before it surprises a piece author: the child merges arrays the other way. Where one array-valued setting appears in several of the child's own scopes, the child concatenates and de-duplicates rather than replacing. The wrapper's pieces are not the child's scopes, and predictability wins inside the wrapper — but a `permissions.allow` split across two pieces behaves differently from the same list split across two of the child's files. This page's own entry in [research tracking](./research-tracking.yaml) owns the freshness of the child's rule.
 
 #### Declaring a strategy
 

--- a/docs/reference/known-issues/README.md
+++ b/docs/reference/known-issues/README.md
@@ -1,0 +1,11 @@
+# Known issues
+
+Defects in systems this project depends on but does not own. A page appears here only after a defect produced a real case in this repository, and it collapses to a closing note once the upstream fix lands and this project drops its workaround.
+
+Each entry names the upstream issue, the case that raised it, the workaround this repository carries, and what to remove when the fix arrives. The workaround itself lives in the file it belongs to, with a comment; this zone records why that file cannot yet be simplified.
+
+A defect with no case here belongs upstream alone. A defect this project caused belongs in a decision record instead.
+
+| System      | Page                            |
+| ----------- | ------------------------------- |
+| release-kit | [release-kit](./release-kit.md) |

--- a/docs/reference/known-issues/release-kit.md
+++ b/docs/reference/known-issues/release-kit.md
@@ -1,0 +1,39 @@
+# release-kit
+
+release-kit owns this project's release convention and the files its landing wrote ([ADR-0118](../../decisions/ADR-0118-adopt-the-release-kit-trunk-convention.md)). The adoption in September 2026 produced three real cases. Each one is filed upstream and worked around here.
+
+## The dist profile is missing, so a first release ships no binaries
+
+Upstream: [gubasso/release-kit#113](https://github.com/gubasso/release-kit/issues/113).
+
+The landed workflow builds release artifacts with the `dist` Cargo profile. `dist generate` writes the workflow but never that profile, and only `dist init` writes it. A landed target therefore carries a workflow that names a profile its own `Cargo.toml` does not define.
+
+Case: version `0.1.1` published its source to crates.io, then every artifact job failed on `profile 'dist' is not defined`. The source release is permanent, so `0.1.1` has binaries nowhere and no GitHub release page. Version `0.1.2` fixed it forward.
+
+Workaround: `Cargo.toml` carries a `[profile.dist]` block with the reason beside it.
+
+Remove when: release-kit's rust binding lands the profile or refuses a landing without one. The block stays either way if the binding only warns.
+
+## A workspace root tags outside the protected pattern
+
+Upstream: [gubasso/release-kit#114](https://github.com/gubasso/release-kit/issues/114).
+
+The `release-tags` ruleset that `rk setup` installs protects `refs/tags/v*`. For a workspace root, release-plz defaults to `<crate>-v{{ version }}`, which that pattern does not match, so the release tag is deletable and movable by anyone with write access.
+
+Case: this manifest is a workspace root with an `xtask` member, so the tag `claude-session-v0.1.1` exists outside the protection. It keeps its name, because renaming a published tag breaks anything that already resolved it.
+
+Workaround: `release-plz.toml` pins `git_tag_name = "v{{ version }}"`.
+
+Remove when: release-kit seeds that key for a workspace target, or its protection covers the workspace tag shape.
+
+## The generated changelog fights the formatter
+
+Upstream: [gubasso/release-kit#115](https://github.com/gubasso/release-kit/issues/115).
+
+release-plz writes the changelog with its own default header and body template. This repository runs `dprint` over every Markdown file and forbids decorative emphasis. The default header wraps a sentence that `dprint` unwraps, and the default body writes a scope as italics and the breaking marker as bold.
+
+Case: the emphasis contract failed on every release request, so no release could merge. After that was fixed, the trunk was dirty after each release, because the next `just hooks` run unwrapped the header again.
+
+Workaround: `release-plz.toml` carries a `[changelog]` section with a rewrapped `header` and two `postprocessors`.
+
+Remove when: release-kit either excludes the generated changelog from a target's formatter and prose gates, or seeds a template that survives them.

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -71,7 +71,9 @@ semver_check = false
 
 `semver_check` is disabled only because the `claude_session` library target exists for this crate's own tests and no external consumer holds that API. The CLI compatibility is still versioned. `git_release_enable` is false because cargo-dist creates the GitHub Release, being the half that has the installers to attach.
 
-A `[changelog]` section carries two postprocessors. The default template writes the scope as `*(scope)*` and the breaking marker as `[**breaking**]`, and `AGENTS.md` forbids decorative emphasis in every Markdown file, the generated changelog included. Without them the repository contract fails on the release request and no release can merge.
+A `[changelog]` section carries a rewrapped header and two postprocessors. The default template writes the scope as `*(scope)*` and the breaking marker as `[**breaking**]`, and `AGENTS.md` forbids decorative emphasis in every Markdown file, the generated changelog included. Without them the repository contract fails on the release request and no release can merge.
+
+Three of the values above work around defects in release-kit rather than expressing a preference of this project. [Known issues](./known-issues/release-kit.md) records each upstream issue and what to delete when its fix lands: the `git_tag_name` pin, the `[changelog]` section, and `Cargo.toml`'s `[profile.dist]` block.
 
 ## Package metadata and contents
 

--- a/docs/reference/research-tracking.yaml
+++ b/docs/reference/research-tracking.yaml
@@ -60,24 +60,6 @@ tracked:
     dependents:
       - docs/reference/testing-and-quality.md
 
-  - path: .github/workflows/release-plz.yml
-    last_checked: 2026-07-30
-    cadence: quarterly
-    why: Publishing identities, action contracts, tag pins, and forge token behavior are externally controlled.
-    revalidate: >-
-      Compare every action tag with current releases and advisories. Re-check
-      crates.io Trusted Publishing identity fields, supported triggers,
-      enforcement, and first-publish requirements. Re-check release-plz
-      commands, default-branch behavior, OIDC authentication, outputs, and tag
-      shape. Re-check GitHub default-token retriggering, the installed-App token
-      action's inputs and behavior, and personal-account ruleset bypass actors.
-      Use the current public crates.io, release-plz, GitHub Actions, action, and
-      ruleset documentation.
-    dependents:
-      - docs/guides/releasing.md
-      - docs/reference/release-workflow.md
-      - release-plz.toml
-
   - path: .github/workflows/release.yml
     last_checked: 2026-07-30
     cadence: quarterly
@@ -275,7 +257,12 @@ tracked:
       default branch, OIDC, outputs, and tags; GitHub default-token retriggering,
       installed-App token inputs, and personal-account bypass actors; and
       cargo-dist's stable schema, workflow trigger, targets, runners, and
-      generated actions. Reconcile any drift with the three workflow entries.
+      generated actions. Reconcile any drift with the two workflow entries.
+      `.github/workflows/release-plz.yml` carries no entry of its own, because
+      release-kit owns that file: `rk status --check` reports drift against the
+      version release-kit landed, and `rk versions --check` compares its action
+      pins with their sources. An action pin that moved there is upgraded
+      through `rk upgrade`, never by editing the file (ADR-0118).
     dependents:
       - .github/workflows/release-plz.yml
       - .github/workflows/release.yml


### PR DESCRIPTION
Five post-release documentation followups, found by sweeping the tree after the release-kit adoption landed.

`ADR-0022` claimed `Cargo.toml` held `0.1.0` as an unreleased authoring version and that its tag did not exist. Five versions are on crates.io and the trunk carries `0.1.4`, so the status becomes `Implemented` and its evidence paragraph names what happened. The record stays under the 350-word limit.

Research tracking kept an entry telling a reader to revalidate `.github/workflows/release-plz.yml` by hand. release-kit owns that file now, and `rk status --check` with `rk versions --check` is what reads it, so the entry folds into the `release-workflow.md` one, which already covers the same external facts.

`cli-surface.md` and `configuration.md` each named a research-tracking fact id. Those keys were dropped when the registry became per-artifact, so both now name the owning entry.

The version output in `cli-surface.md` says it illustrates a shape. The numbers in it were never a claim about a current release, and no test asserts them.

`docs/reference/known-issues/` is new. `AGENTS.md` reserves it for a defect in a system this project depends on, once a real case exists. The release-kit adoption produced three, filed upstream as gubasso/release-kit#113, #114, and #115. Each one is worked around in a file that otherwise looks unexplained: `Cargo.toml`'s `[profile.dist]` block, the `git_tag_name` pin, and the `[changelog]` section. The page records what to delete when each fix lands.

`just hooks` is green on both stages.