### PR TITLE
ci(scorecard): adopt the openssf scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,61 @@
+# OpenSSF Scorecard, the supply-chain self-assessment (ADR-0120).
+#
+# This file is shaped by the publishing API rather than by taste. It rejects
+# results from a workflow that carries top-level `env` or `defaults`, that
+# grants a write permission at the workflow level, that gives `id-token: write`
+# to a job other than the one running the action, or that runs a step outside
+# its approved action list. Read those rules before editing anything here:
+# https://github.com/ossf/scorecard-action#workflow-restrictions
+#
+# The results are advisory. No job here gates a pull request, and the required
+# check stays the `gate` job in ci.yml. A score is a signal to read, never a
+# merge condition.
+name: scorecard
+
+on:
+  push:
+    # The publisher accepts the default branch alone.
+    branches: [master]
+  schedule:
+    # Weekly, on Tuesday. The score reads repository state rather than a
+    # change, so it needs a heartbeat as well as a push.
+    - cron: "27 4 * * 2"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      # The code-scanning upload.
+      security-events: write
+      # The OIDC token that proves to the publisher which workflow produced
+      # this result. Required by `publish_results`, and held by this job only.
+      id-token: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The analysis reads public repository state through its own token,
+          # so the checkout keeps no credential in the workspace.
+          persist-credentials: false
+
+      - name: Run the analysis
+        uses: ossf/scorecard-action@v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Keep the raw result for five days
+        uses: actions/upload-artifact@v7
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # claude-session
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/gubasso/claude-session/badge)](https://scorecard.dev/viewer/?uri=github.com/gubasso/claude-session)
+
 A Rust CLI that wraps the `claude` command with session-oriented conveniences.
 
 > Status: unreleased. The wrapper forwards to `claude` natively and owns `help`, `version`, `doctor`, the `account` and `session` namespaces, `completion`, `man`, `profile`, and `config`. Everything else described in [docs](./docs/README.md) is design ahead of the code.

--- a/docs/decisions/ADR-0073-defer-openssf-scorecard-until-the-first-release.md
+++ b/docs/decisions/ADR-0073-defer-openssf-scorecard-until-the-first-release.md
@@ -28,8 +28,8 @@ Declining permanently is rejected. The present coverage — `cargo audit`, `carg
 
 ## Status
 
-Accepted
+Superseded
 
-Recorded as a not-adopted row in [release workflow § Forge enforcement](../reference/release-workflow.md#forge-enforcement).
+The trigger fired once `0.1.0` shipped and the rulesets went live. [ADR-0120](./ADR-0120-adopt-the-openssf-scorecard-workflow.md) adopts Scorecard and carries the reasoning that replaces this deferral.
 
-Amended by [ADR-0118](./ADR-0118-adopt-the-release-kit-trunk-convention.md): the trigger now reads the `master-protection` and `release-tags` rulesets the release-kit setup installs, since `develop` no longer exists. The deferral itself is unchanged.
+Amended by [ADR-0118](./ADR-0118-adopt-the-release-kit-trunk-convention.md): the trigger read the `master-protection` and `release-tags` rulesets the release-kit setup installs, because `develop` no longer exists.

--- a/docs/decisions/ADR-0120-adopt-the-openssf-scorecard-workflow.md
+++ b/docs/decisions/ADR-0120-adopt-the-openssf-scorecard-workflow.md
@@ -1,0 +1,32 @@
+# ADR-0120: Adopt the OpenSSF Scorecard workflow
+
+## Context and Problem Statement
+
+[ADR-0073](./ADR-0073-defer-openssf-scorecard-until-the-first-release.md) deferred Scorecard behind a named trigger: a first tagged release, live rulesets, and release history to read. All three now hold. Five versions are on crates.io, the `master-protection` and `release-tags` rulesets are installed, and every change since the adoption reached the trunk through a squash-merged request.
+
+## Considered Options
+
+- Adopt it, and publish the result to the public API.
+- Adopt it, and keep the result in this repository's security tab.
+- Keep deferring it, or decline it permanently.
+
+## Decision Outcome
+
+Chosen option: adopt it and publish, because the value is a supply-chain reading a consumer can check without trusting this repository's own prose.
+
+`.github/workflows/scorecard.yml` runs on a push to `master` and weekly. It gates nothing. No job in it reports on a pull request, and the required check stays `gate` in `ci.yml`. Its shape follows the publisher's rules rather than this project's taste, because the API rejects a result from a workflow carrying top-level `env`, a workflow-level write permission, or `id-token: write` on a second job.
+
+Two checks will score below their maximum, knowingly. Branch-Protection reads protection settings through a long-lived personal token, which [ADR-0039](./ADR-0039-use-a-github-app-for-release-automation.md) replaced with a short-lived App token. Pinned-Dependencies wants a commit SHA for every action, and this project pins a version tag so `rk versions --check` can read it. Both are decisions rather than gaps, and changing either is its own record.
+
+## Consequences
+
+- Good: a third party measures what this repository claims, weekly, and publishes the result.
+- Good: a regression in the release path shows as a falling score rather than as silence.
+- Bad: two checks score low for recorded reasons, so the number needs this record to read it.
+- Bad: one more scheduled workflow, and four more action pins to keep current.
+
+## Status
+
+Implemented
+
+Enacted in [the Scorecard workflow](../../.github/workflows/scorecard.yml). Supersedes [ADR-0073](./ADR-0073-defer-openssf-scorecard-until-the-first-release.md).

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -41,6 +41,7 @@ Never register `release.yml` as the publisher. The first publish uses a disposab
 | `.github/workflows/pr-title.yml`    | The Conventional Commits check on the request title                        | release-kit  |
 | `.github/workflows/release-plz.yml` | Release request, source publish, and tag creation                          | release-kit  |
 | `.github/workflows/release.yml`     | Cargo-dist-generated tag workflow and GitHub Release assets                | cargo-dist   |
+| `.github/workflows/scorecard.yml`   | The weekly OpenSSF Scorecard run, which gates nothing                      | this project |
 | `release-plz.toml`                  | Source-release policy                                                      | this project |
 | `dist-workspace.toml`               | Binary-distribution policy                                                 | this project |
 | `nix/package.nix`                   | The package expression the pipeline builds                                 | this project |
@@ -136,7 +137,7 @@ This is external state the repository cannot assert, and it is no longer tracked
 
 Rulesets are used rather than classic branch protection: they compose, they are readable by non-admins, they cover tags as well as branches, and they express a bypass actor explicitly. The bypass actor must be the installed App; naming `github-actions[bot]` instead fails with HTTP 422 from the ruleset API, because a personal account cannot use it as a bypass actor ([ADR-0039](../decisions/ADR-0039-use-a-github-app-for-release-automation.md)).
 
-Not adopted: OpenSSF Scorecard. Deferred until after the first tagged release, with the trigger and the reasoning in [ADR-0073](../decisions/ADR-0073-defer-openssf-scorecard-until-the-first-release.md).
+OpenSSF Scorecard reads this repository weekly and on every push to `master`, and publishes the result to the public API. `.github/workflows/scorecard.yml` owns the run. It gates nothing, so the one required check stays `gate` in `ci.yml`. Branch-Protection and Pinned-Dependencies score below their maximum for recorded reasons, and [ADR-0120](../decisions/ADR-0120-adopt-the-openssf-scorecard-workflow.md) carries both.
 
 ## Further reading
 

--- a/docs/reference/research-tracking.yaml
+++ b/docs/reference/research-tracking.yaml
@@ -60,6 +60,21 @@ tracked:
     dependents:
       - docs/reference/testing-and-quality.md
 
+  - path: .github/workflows/scorecard.yml
+    last_checked: 2026-09-09
+    cadence: quarterly
+    why: The publisher's rules on the producing workflow, the approved action list, and the four action pins are all externally controlled, and a rejected result fails the run rather than degrading it.
+    revalidate: >-
+      Compare every action tag in this workflow with the action's current
+      release and security advisories. Re-read the scorecard-action workflow
+      restrictions and its approved action list, since a rule added there makes
+      a previously accepted workflow fail. Re-check which checks read a
+      long-lived token, because the two this project knowingly scores low on
+      are the reason ADR-0120 reads the number rather than chasing it.
+    dependents:
+      - docs/decisions/ADR-0120-adopt-the-openssf-scorecard-workflow.md
+      - docs/reference/release-workflow.md
+
   - path: .github/workflows/release.yml
     last_checked: 2026-07-30
     cadence: quarterly


### PR DESCRIPTION
`ADR-0073` deferred OpenSSF Scorecard behind a named trigger: a first tagged release, live rulesets, and release history to read. All three now hold. Five versions are on crates.io, the `master-protection` and `release-tags` rulesets are installed, and every change since the release-kit adoption reached the trunk through a squash-merged request. `ADR-0120` supersedes the deferral and this change enacts it.

`.github/workflows/scorecard.yml` runs on a push to `master` and weekly on Tuesday, publishes the result to the public API, uploads the SARIF to code scanning, and keeps the raw file as an artifact for five days.

It gates nothing. No job in it reports on a pull request, so the one required check stays `gate` in `ci.yml`. The file's shape follows the publisher's rules rather than this project's taste, because the API rejects a result from a workflow carrying top-level `env`, a workflow-level write permission, or `id-token: write` on a second job. The header says so, with the link.

Two checks will score below their maximum, knowingly. Branch-Protection reads protection settings through a long-lived personal token, which `ADR-0039` replaced with a short-lived App token. Pinned-Dependencies wants a commit SHA for every action, and this project pins a version tag so `rk versions --check` can read it. `ADR-0120` records both, so the number is read rather than chased.

`README.md` carries the badge, which stays blank until the first published run. `release-workflow.md` replaces its not-adopted row and gains the ownership line, and `research-tracking.yaml` gains a quarterly entry for the four new action pins and for the publisher rules that can change under them.

`just hooks` is green on both stages.