### PR TITLE
chore(release): move release-kit to 0.3.5

### DIFF
--- a/.release-kit/manifest.json
+++ b/.release-kit/manifest.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 5,
-  "rk_version": "0.3.3",
-  "payload_sha256": "51b905d58e296f5df7bd3594e76f8a55e58b2765a5cecae25950ea907aecfc65",
+  "rk_version": "0.3.5",
+  "payload_sha256": "73c6eb250722787e3f43da9948340a5b407bf152fda657272fd13b5a00d4f803",
   "origin": "init",
   "tech": "rust",
   "forge": "github",
@@ -52,7 +52,7 @@
     {
       "destination": "release-plz.toml",
       "kind": "seeded",
-      "sha256": "3a34773d3246e70bd420e3232eabae46fe6c25e0812a16f4d0b19a253a52035e",
+      "sha256": "e21987a4f0bd3fba51e7c5727e662a25737090c18a0834c5b11f322e81ab9907",
       "baseline_sha256": "0983ed155c83959d08f4446b91fb9dfcfebc80284babe49969bed4eaa0e55f1d"
     }
   ],

--- a/flake.lock
+++ b/flake.lock
@@ -42,16 +42,16 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1788896309,
-        "narHash": "sha256-3Ok1/lmjSiSc2xaI1qp4WVoj8TNR+nuyIJ266vV0M6M=",
+        "lastModified": 1788918459,
+        "narHash": "sha256-dKOT89W+NYHqOV2CCxVySGGAkI//J+drCuWIcoFY438=",
         "owner": "gubasso",
         "repo": "release-kit",
-        "rev": "3ee4388c1c74e5eb2f98ad46d5b6ff4a2f2ccf05",
+        "rev": "69d847cade54e051b163199a258193762d49b41a",
         "type": "github"
       },
       "original": {
         "owner": "gubasso",
-        "ref": "v0.3.3",
+        "ref": "v0.3.5",
         "repo": "release-kit",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -10,7 +10,7 @@
     # pin and the lock together, so the project supplies its own `rk` instead of
     # depending on a host install.
     release-kit = {
-      url = "github:gubasso/release-kit/v0.3.3";
+      url = "github:gubasso/release-kit/v0.3.5";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
Move the devshell pin and the landing record from release-kit 0.3.3 to
0.3.5, so the convention this repository runs is the one release-kit
ships.

The payload is identical between the two versions. `rk upgrade` rewrites
`.release-kit/manifest.json` alone, and no workflow, hook block, or
document changes. The three releases in between changed the rust
binding's prose, the landing record's version, and the upgrade preview.

The record also re-takes the hash of `release-plz.toml`, which this
project owns and tunes, while keeping its original baseline. So
`rk status --check` now reports no drift line where it used to report
that seeded file.

`rk versions --check` names four pins behind their sources. None is in a
file this project owns: two are release-kit's own, one is cargo-dist
output, and `ci.yml` and `scorecard.yml` already carry `checkout@v7` and
`nix-installer-action@v22`.
