### PR TITLE
docs(security): state a vulnerability reporting path

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,3 +218,5 @@ Unless you explicitly state otherwise, any contribution intentionally submitted 
 ## Contributing
 
 Contributions are welcome. Please open an issue to discuss substantial changes before submitting a pull request, and run the full gate first — [the development workflow](./docs/guides/development-workflow.md) has the procedure.
+
+Report a vulnerability privately instead of opening an issue. [The security policy](./SECURITY.md) has the channel.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,25 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report a vulnerability privately through [GitHub private vulnerability reporting](https://github.com/gubasso/claude-session/security/advisories/new). Do not open a public issue for one.
+
+Include what you have: a description of the problem, the steps that reproduce it, the version you saw it on, and any mitigation you know of.
+
+## What happens next
+
+One maintainer reads the report. Handling is best effort, so expect a first reply in weeks rather than days, and expect it to say whether the report is accepted or declined.
+
+An accepted report becomes a GitHub security advisory on this repository, which is also how a fix is announced. A published advisory reaches the [RustSec advisory database](https://rustsec.org), so `cargo audit` sees it.
+
+## Supported versions
+
+Only the latest published version is supported. This project is `0.x`, a fix ships as a new version rather than as a patch to an older one, and a yank contains a bad version rather than recovering it. [The release workflow](https://github.com/gubasso/claude-session/blob/master/docs/reference/release-workflow.md) owns that policy.
+
+## Dependency advisories
+
+A CVE in a dependency is not by itself a vulnerability in this wrapper. CI already runs `cargo audit` and `cargo deny` on every change, so a report that names a version and an advisory id, with no path showing the problem is reachable from this code, tells nobody anything new. Show the reachable path or the proof of concept.
+
+## What this project cannot do
+
+This is a wrapper around the `claude` CLI. A vulnerability in `claude` itself, in the Anthropic API, or in a dependency belongs to whoever owns that code. Report it there. This policy covers the wrapper.

--- a/docs/decisions/ADR-0121-report-a-vulnerability-through-the-forge.md
+++ b/docs/decisions/ADR-0121-report-a-vulnerability-through-the-forge.md
@@ -1,0 +1,34 @@
+# ADR-0121: Report a vulnerability through the forge
+
+## Context and Problem Statement
+
+Five versions are on crates.io and no document says where a vulnerability report goes, so the only channel is the public issue tracker, which discloses the problem in the act of reporting it. [ADR-0120](./ADR-0120-adopt-the-openssf-scorecard-workflow.md) published a Scorecard reading whose Security-Policy check is zero for that reason.
+
+## Considered Options
+
+- GitHub private vulnerability reporting alone.
+- A published address alone.
+- Both, with the address as a fallback.
+
+## Decision Outcome
+
+Chosen option: private vulnerability reporting alone, because it publishes no address to scrape, its thread becomes the advisory that `cargo audit` reads, and one channel is one place to watch.
+
+A published address works for a reporter with no forge account, and `gu@gubasso.xyz` is already public in `Cargo.toml`. It costs a mailbox to triage for the life of the project. One maintainer watching two channels watches neither reliably, so the fallback loses to the same argument as the address alone. If a report ever fails to reach the maintainer, the address joins the policy then.
+
+The setting is on. `gh api -X PUT repos/gubasso/claude-session/private-vulnerability-reporting` enabled it, and the `GET` on that path reads it back.
+
+Only the latest published version is supported, which restates [the release workflow](../reference/release-workflow.md) rather than deciding anything new.
+
+## Consequences
+
+- Good: a reporter has one private channel, and the advisory it produces reaches RustSec without further work.
+- Good: the policy states what this wrapper does not own, so a `claude` or dependency problem goes to its owner.
+- Bad: a reporter with no GitHub account has no route, which is the cost taken knowingly.
+- Bad: the channel depends on a forge setting, so a reader must check it rather than trust this record.
+
+## Status
+
+Implemented
+
+Enacted in [the security policy](../../SECURITY.md).

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -131,6 +131,8 @@ Recovery is a new version. Yank is containment, not recovery. Yanking removes a 
 
 A yank also cannot un-publish a leaked secret. If one reached the package, rotate it immediately and treat the yank as irrelevant to the exposure.
 
+A vulnerability report arrives privately through the forge and leaves as a fix-forward release under this policy. [The security policy](../../SECURITY.md) owns the reporting channel and what a reporter can expect, and [ADR-0121](../decisions/ADR-0121-report-a-vulnerability-through-the-forge.md) records why that channel and no other.
+
 ## Forge enforcement
 
 This is external state the repository cannot assert, and it is no longer tracked as a dated manual reading. `rk setup check --target .` proves every row against the forge, step by step, and `rk setup --target . --apply --required-check <name>` re-asserts them. [The release guide](../guides/releasing.md) carries the order and what stays the operator's.


### PR DESCRIPTION
Five versions are published and nothing said where a vulnerability report
goes, so the only channel was the public issue tracker, which discloses the
problem in the act of reporting it.

SECURITY.md names one private channel, GitHub private vulnerability
reporting, and states what a reporter can expect from a single maintainer:
best effort, a reply in weeks, and an advisory that reaches RustSec so
cargo audit sees the fix. It also refuses dependency-CVE reports that show
no reachable path into this code, and says a bug in claude itself belongs
to whoever owns claude.

ADR-0121 records why that channel and no other. A published address would
serve a reporter with no forge account and costs a mailbox to triage for
the life of the project; one maintainer watching two channels watches
neither. The release workflow gains a paragraph pointing at both, and the
README routes a report away from the issue tracker.

The forge setting the policy depends on is already on.

