### PR TITLE
docs(scorecard): connect the dependency-bot refusal to its zero

### DIFF
--- a/docs/decisions/ADR-0023-only-release-automation-opens-pull-requests.md
+++ b/docs/decisions/ADR-0023-only-release-automation-opens-pull-requests.md
@@ -22,6 +22,7 @@ An upgrade is therefore an ordinary human change: run `cargo update` or edit the
 - Good: no third-party forge service holds write access to the pull-request stream.
 - Bad: pinned actions drift silently behind their tags, so their currency is a tracked perishable fact ([research-tracking](../reference/research-tracking.yaml)) rather than an automated one.
 - Bad: an advisory the gate reports arrives with no fix waiting; someone has to write it.
+- Bad: OpenSSF Scorecard reads this refusal as a Dependency-Update-Tool zero, so the number needs this record to read it.
 
 ## Status
 

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -139,7 +139,7 @@ This is external state the repository cannot assert, and it is no longer tracked
 
 Rulesets are used rather than classic branch protection: they compose, they are readable by non-admins, they cover tags as well as branches, and they express a bypass actor explicitly. The bypass actor must be the installed App; naming `github-actions[bot]` instead fails with HTTP 422 from the ruleset API, because a personal account cannot use it as a bypass actor ([ADR-0039](../decisions/ADR-0039-use-a-github-app-for-release-automation.md)).
 
-OpenSSF Scorecard reads this repository weekly and on every push to `master`, and publishes the result to the public API. `.github/workflows/scorecard.yml` owns the run. It gates nothing, so the one required check stays `gate` in `ci.yml`. Branch-Protection and Pinned-Dependencies score below their maximum for recorded reasons, and [ADR-0120](../decisions/ADR-0120-adopt-the-openssf-scorecard-workflow.md) carries both.
+OpenSSF Scorecard reads this repository weekly and on every push to `master`, and publishes the result to the public API. `.github/workflows/scorecard.yml` owns the run. It gates nothing, so the one required check stays `gate` in `ci.yml`. Branch-Protection and Pinned-Dependencies score below their maximum for recorded reasons, and [ADR-0120](../decisions/ADR-0120-adopt-the-openssf-scorecard-workflow.md) carries both. Dependency-Update-Tool scores zero because this project refuses a dependency bot, and [ADR-0023](../decisions/ADR-0023-only-release-automation-opens-pull-requests.md) carries that refusal.
 
 ## Further reading
 


### PR DESCRIPTION
OpenSSF Scorecard scores the Dependency-Update-Tool check zero. That zero
is not a gap. ADR-0023 is Accepted and refuses a dependency-update bot on
the record, because machine-proposed bumps move the dependency set on a
schedule the project did not choose. The decision predates the score, and
no document connected the refusal to the number, so a reader who saw the
zero could not reach the reason.

Restate the decision rather than re-decide it. Part of the drift ADR-0023
accepted is now automated: rk versions --check reads every pin release-kit
owns against its source, and rk upgrade moves them. That does not reach the
files ADR-0023 names. The manifest lists only pr-title.yml and
release-plz.yml among workflows, so this project still owns ci.yml, which
pins actions/checkout, nix-installer-action and flakehub-cache-action by
mutable tag. The recorded cost is unchanged and the refusal stands.

Add the consequence to ADR-0023 and name the third check in the Forge
enforcement section, beside the two ADR-0120 already carries. The record
follows ADR-0120's shape, which puts a scoring cost in Consequences and
keeps Status for the status word and record pointers.

The record goes from 320 to 340 words against the 350 cap.

