### PR TITLE
ci(codeql): adopt codeql and record why

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+# CodeQL analysis for the Rust surfaces named by ADR-0122.
+#
+# Results are advisory. They reach the security tab but do not join the required
+# gate in ci.yml.
+name: codeql
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  schedule:
+    # Weekly, on Wednesday.
+    - cron: "43 4 * * 3"
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: codeql analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: rust
+          build-mode: none
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4

--- a/docs/decisions/ADR-0122-adopt-codeql-for-rust-analysis.md
+++ b/docs/decisions/ADR-0122-adopt-codeql-for-rust-analysis.md
@@ -1,0 +1,35 @@
+# ADR-0122: Adopt CodeQL for Rust analysis
+
+## Context and Problem Statement
+
+The Scorecard SAST zero is misleading rather than false: this project runs Clippy at `all`, `pedantic`, and `nursery`, forbids `unsafe_code`, and runs `cargo-audit` and `cargo-deny`. Scorecard recognizes tool identities, so raising its number is not a reason to add a scanner.
+
+The reason is this wrapper's process-launching and XDG-path-resolving surface. On 2026-09-09, the CodeQL Rust corpus held 20 security queries across 17 CWE directories; CWE-078 command injection, CWE-022 path traversal, CWE-117 log injection, and CWE-798 hard-coded credentials reach it directly. [Rust support became generally available](https://github.blog/changelog/2025-10-14-codeql-scanning-rust-and-c-c-without-builds-is-now-generally-available/) on 2025-10-14 and requires build-free analysis.
+
+## Considered Options
+
+- Run CodeQL beside the Scorecard workflow and gate nothing.
+- Put CodeQL in `ci.yml` and join it to the required `gate` job.
+- Run Semgrep Community Edition.
+
+## Decision Outcome
+
+Chosen option: run CodeQL beside Scorecard, because its queries cover security-sensitive surfaces that one reviewer cannot exhaustively check by hand.
+
+`.github/workflows/codeql.yml` analyzes Rust with `build-mode: none` on pull requests, pushes to `master`, and weekly, reporting into the security tab. It gates nothing. One maintainer reviews everything, so a false finding holding a merge costs more than a true finding waiting there; [ADR-0120](./ADR-0120-adopt-the-openssf-scorecard-workflow.md) established this placement.
+
+Putting the job in `ci.yml` is the only option that stops a defect from landing and would suit more reviewers. Semgrep's smaller Rust corpus adds less, and its unsafe-use rule is already unreachable.
+
+## Consequences
+
+- Good: process, path, log, and credential risks receive a specialized independent reading.
+- Bad: three mutable action references and a scheduled workflow require maintenance.
+- Bad: Scorecard may rise because it recognizes CodeQL, but that change measures tool identity rather than the reason for adoption.
+- Constraint: [the terms](https://github.com/github/codeql-cli-binaries/blob/main/LICENSE.md) permit use while this public repository declares the OSI-approved `MIT OR Apache-2.0` licence. If either visibility or licence changes, this adoption stops being permitted without a paid GitHub Code Security seat.
+- Observation: GitHub detects the pointer `LICENSE` as `Other`; the declared SPDX expression is authoritative.
+
+## Status
+
+Implemented
+
+Enacted in [the CodeQL workflow](../../.github/workflows/codeql.yml).

--- a/docs/reference/release-workflow.md
+++ b/docs/reference/release-workflow.md
@@ -37,6 +37,7 @@ Never register `release.yml` as the publisher. The first publish uses a disposab
 
 | File                                | Responsibility                                                             | Owner        |
 | ----------------------------------- | -------------------------------------------------------------------------- | ------------ |
+| `.github/workflows/codeql.yml`      | Rust CodeQL analysis reported to the security tab, which gates nothing     | this project |
 | `.github/workflows/ci.yml`          | Validation on `master` pushes and all pull requests, and the required gate | this project |
 | `.github/workflows/pr-title.yml`    | The Conventional Commits check on the request title                        | release-kit  |
 | `.github/workflows/release-plz.yml` | Release request, source publish, and tag creation                          | release-kit  |
@@ -139,7 +140,7 @@ This is external state the repository cannot assert, and it is no longer tracked
 
 Rulesets are used rather than classic branch protection: they compose, they are readable by non-admins, they cover tags as well as branches, and they express a bypass actor explicitly. The bypass actor must be the installed App; naming `github-actions[bot]` instead fails with HTTP 422 from the ruleset API, because a personal account cannot use it as a bypass actor ([ADR-0039](../decisions/ADR-0039-use-a-github-app-for-release-automation.md)).
 
-OpenSSF Scorecard reads this repository weekly and on every push to `master`, and publishes the result to the public API. `.github/workflows/scorecard.yml` owns the run. It gates nothing, so the one required check stays `gate` in `ci.yml`. Branch-Protection and Pinned-Dependencies score below their maximum for recorded reasons, and [ADR-0120](../decisions/ADR-0120-adopt-the-openssf-scorecard-workflow.md) carries both. Dependency-Update-Tool scores zero because this project refuses a dependency bot, and [ADR-0023](../decisions/ADR-0023-only-release-automation-opens-pull-requests.md) carries that refusal.
+OpenSSF Scorecard reads this repository weekly and on every push to `master`, and publishes the result to the public API. `.github/workflows/scorecard.yml` owns the run. It gates nothing, so the one required check stays `gate` in `ci.yml`. Branch-Protection and Pinned-Dependencies score below their maximum for recorded reasons, and [ADR-0120](../decisions/ADR-0120-adopt-the-openssf-scorecard-workflow.md) carries both. Dependency-Update-Tool scores zero because this project refuses a dependency bot, and [ADR-0023](../decisions/ADR-0023-only-release-automation-opens-pull-requests.md) carries that refusal. CodeQL answers the SAST zero through `.github/workflows/codeql.yml`; it also gates nothing, and [ADR-0122](../decisions/ADR-0122-adopt-codeql-for-rust-analysis.md) records why.
 
 ## Further reading
 

--- a/docs/reference/research-tracking.yaml
+++ b/docs/reference/research-tracking.yaml
@@ -60,6 +60,19 @@ tracked:
     dependents:
       - docs/reference/testing-and-quality.md
 
+  - path: .github/workflows/codeql.yml
+    last_checked: 2026-09-09
+    cadence: quarterly
+    why: The three action pins and CodeQL's Rust extractor support are externally controlled.
+    revalidate: >-
+      Compare every action tag in this workflow with the action's current
+      release and security advisories. Re-check that the resolved CodeQL bundle
+      supports Rust with `build-mode: none`, and re-read the CodeQL CLI licence
+      terms before either the repository visibility or declared licence changes.
+    dependents:
+      - docs/decisions/ADR-0122-adopt-codeql-for-rust-analysis.md
+      - docs/reference/release-workflow.md
+
   - path: .github/workflows/scorecard.yml
     last_checked: 2026-09-09
     cadence: quarterly


### PR DESCRIPTION
## Summary

- add advisory Rust CodeQL analysis for pull requests, master pushes, and a weekly schedule
- record why process and path surfaces justify the scanner and when its licence eligibility ends
- register workflow ownership and externally controlled action pins

## Verification

- just hooks